### PR TITLE
Add `__version__` to EchoPro

### DIFF
--- a/EchoPro/__init__.py
+++ b/EchoPro/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+from _echopro_version import __version__
+
 from .survey import Survey
 from .create_preliminary_files import CreateFiles
 from .generate_reports import GenerateReports

--- a/_echopro_version.py
+++ b/_echopro_version.py
@@ -1,0 +1,1 @@
+__version__ = "0.1.0-alpha"


### PR DESCRIPTION
In this PR I add `__version__` to EchoPro. It can now be accessed via the following: 

```
import EchoPro
EchoPro.__version__
```

I saw some discussion on using `version` vs `__version__` online. From what I can gather `__version__` is preferred and referenced in PEP8. 

I also added the file `_echopro_version.py`, which is the location of the actual value of `__version__`. I think in the future we can make it so that `_echopro_version.py` is automatically generated. 