### PR TITLE
Set new release version to 0.2.0-alpha

### DIFF
--- a/_echopro_version.py
+++ b/_echopro_version.py
@@ -1,1 +1,1 @@
-__version__ = "0.2.0-alpha"
+__version__ = "0.2.0"


### PR DESCRIPTION
[Previously](https://github.com/uw-echospace/EchoPro/milestone/3) we were targeting the new version as 0.1.1-alpha. I think there is plenty of substantial changes here, so I suggest we go to 0.2.0-alpha instead. Thoughts?

@leewujung: @b-reyes and I made the executive decision on the first release (0.1.0-alpha) to use the "-alpha" suffix. Should we stick with that, or do you think it's unnecessary?

BTW, I've created draft text for the release. I'll create a release draft with that text later this afternoon, for your review. But it'll be cleaner if we first make a decision about the version designation.