### PR TITLE
Cleanups to comments and annotations in main config yaml file

### DIFF
--- a/config_files/survey_year_2019_config.yml
+++ b/config_files/survey_year_2019_config.yml
@@ -1,7 +1,7 @@
 # This YAML file is a configuration file specifying
 # input filenames & some process parameter settings.
 # Relative file paths defined below are concatenated 
-# with the data_root_dir set path set below.
+# with the data_root_dir path also set below.
 
 ---
 


### PR DESCRIPTION
- For stratification files, moved to stand-alone lines and expanded the "# INPFC" comment that specified the additional sheet available in the file
- Trimmed to 80-character length the section dividers, to minimize line-wrap clutter
- Moved to the top block the repeated comment lines about file paths being concatenated with the `data_root_dir`
