### PR TITLE
Update pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,12 @@
 exclude: |
   (?x)^(
-    echopop/tests/|
+    echopop/test_data/|
     docs/|
-    example_notebooks/|
     project_docs
   )
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.6.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -18,23 +17,23 @@ repos:
         args: ["--autofix", "--indent=2", "--no-sort-keys"]
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.11.1
+    rev: 5.13.2
     hooks:
       - id: isort
         args: ["--profile", "black", "--filter-files"]
 
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 24.4.0
     hooks:
       - id: black
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 7.0.0
     hooks:
       - id: flake8
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.2
+    rev: v2.2.6
     hooks:
       - id: codespell
         args: ["--skip=*.ipynb", "-w", "docs/source", "echopype", "echopop"]


### PR DESCRIPTION
This is a quick update to the yaml file, so that I can test running pre-commit locally.

@brandynlucca : The pre-commit setting runs without problem when I tested it. You can run it by `pre-commit run --all-files` -- in the first run it will fix whole bunch of things, and in the second run you would see the things you need to manually fix:
- mostly too many leading '#' in comments
- some imported by unused packages
- a typo codespell is unsure about

It is relatively straightforward to do, so I'd suggest running it sooner than later. Make sure to do it on a new branch/PR! I'll activate the [bot](https://github.com/apps/pre-commit-ci) once you merge that PR. Afterwards the bot will automatically update the package version.