### PR TITLE
Add configuration YAML file validator

### DIFF
--- a/echopop/core.py
+++ b/echopop/core.py
@@ -12,7 +12,7 @@ CONFIG_INIT_API = {
     "stratified_survey_mean_parameters": {
         "strata_transect_proportion": float,
         "num_replicates": int,
-        "mesh_transects_per_latitude": int
+        "mesh_transects_per_latitude": int,
     },
     "bio_hake_len_bin": [float],
     "bio_hake_age_bin": [float],
@@ -21,108 +21,56 @@ CONFIG_INIT_API = {
             "number_code": int,
             "TS_L_slope": float,
             "TS_L_intercept": float,
-            "length_units": str
+            "length_units": str,
         }
     },
-    "geospatial": {
-        "init": str
-    },
+    "geospatial": {"init": str},
     "kriging_parameters": {
         "A0": float,
         "longitude_reference": float,
         "longitude_offset": float,
-        "latitude_offset": float
-    }
+        "latitude_offset": float,
+    },
 }
 
 # Required data configuration YAML structure
 CONFIG_DATA_API = {
     "survey_year": int,
-    "species": {
-        "number_code": int
-    },
+    "species": {"number_code": int},
     "CAN_haul_offset": int,
     "data_root_dir": str,
     "biological": {
         "length": {
-            "US": {
-                "filename": str,
-                "sheetname": str
-            },
-            "CAN": {
-                "filename": str,
-                "sheetname": str                
-            }
+            "US": {"filename": str, "sheetname": str},
+            "CAN": {"filename": str, "sheetname": str},
         },
-        "specimen":  {
-            "US": {
-                "filename": str,
-                "sheetname": str
-            },
-            "CAN": {
-                "filename": str,
-                "sheetname": str                
-            }
+        "specimen": {
+            "US": {"filename": str, "sheetname": str},
+            "CAN": {"filename": str, "sheetname": str},
         },
-        "catch":  {
-            "US": {
-                "filename": str,
-                "sheetname": str
-            },
-            "CAN": {
-                "filename": str,
-                "sheetname": str                
-            }
+        "catch": {
+            "US": {"filename": str, "sheetname": str},
+            "CAN": {"filename": str, "sheetname": str},
         },
-        "haul_to_transect":  {
-            "US": {
-                "filename": str,
-                "sheetname": str
-            },
-            "CAN": {
-                "filename": str,
-                "sheetname": str                
-            }
-        }
+        "haul_to_transect": {
+            "US": {"filename": str, "sheetname": str},
+            "CAN": {"filename": str, "sheetname": str},
+        },
     },
     "stratification": {
-        "strata": {
-            "filename": str,
-            "sheetname": str                
-        },
-        "geo_strata": {
-            "filename": str,
-            "sheetname": [str]  
-        }
+        "strata": {"filename": str, "sheetname": str},
+        "geo_strata": {"filename": str, "sheetname": [str]},
     },
     "NASC": {
-        "no_age1": {
-            "filename": str,
-            "sheetname": str  
-            },
-        "all_ages": {
-            "filename": str,
-            "sheetname": str              
-        }
-
+        "no_age1": {"filename": str, "sheetname": str},
+        "all_ages": {"filename": str, "sheetname": str},
     },
     "kriging": {
-        "mesh": {
-            "filename": str,
-            "sheetname": str  
-        },
-        "isobath_200m": {
-            "filename": str,
-            "sheetname": str  
-        },
-        "vario_krig_para": {
-            "filename": str,
-            "sheetname": str  
-        }
-    }
+        "mesh": {"filename": str, "sheetname": str},
+        "isobath_200m": {"filename": str, "sheetname": str},
+        "vario_krig_para": {"filename": str, "sheetname": str},
+    },
 }
-
-survey_year_config_params["kriging"]
 
 # `Survey` object data structure
 CONFIG_MAP = {

--- a/echopop/core.py
+++ b/echopop/core.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 
 # Required configuration initialization YAML structure
-CONFIG_INIT_API = {
+CONFIG_INIT_MODEL = {
     "stratified_survey_mean_parameters": {
         "strata_transect_proportion": float,
         "num_replicates": int,
@@ -34,7 +34,7 @@ CONFIG_INIT_API = {
 }
 
 # Required data configuration YAML structure
-CONFIG_DATA_API = {
+CONFIG_DATA_MODEL = {
     "survey_year": int,
     "species": {"number_code": int},
     "CAN_haul_offset": int,

--- a/echopop/core.py
+++ b/echopop/core.py
@@ -7,6 +7,123 @@ from datetime import datetime
 import numpy as np
 import pandas as pd
 
+# Required configuration initialization YAML structure
+CONFIG_INIT_API = {
+    "stratified_survey_mean_parameters": {
+        "strata_transect_proportion": float,
+        "num_replicates": int,
+        "mesh_transects_per_latitude": int
+    },
+    "bio_hake_len_bin": [float],
+    "bio_hake_age_bin": [float],
+    "TS_length_regression_parameters": {
+        "ANY": {
+            "number_code": int,
+            "TS_L_slope": float,
+            "TS_L_intercept": float,
+            "length_units": str
+        }
+    },
+    "geospatial": {
+        "init": str
+    },
+    "kriging_parameters": {
+        "A0": float,
+        "longitude_reference": float,
+        "longitude_offset": float,
+        "latitude_offset": float
+    }
+}
+
+# Required data configuration YAML structure
+CONFIG_DATA_API = {
+    "survey_year": int,
+    "species": {
+        "number_code": int
+    },
+    "CAN_haul_offset": int,
+    "data_root_dir": str,
+    "biological": {
+        "length": {
+            "US": {
+                "filename": str,
+                "sheetname": str
+            },
+            "CAN": {
+                "filename": str,
+                "sheetname": str                
+            }
+        },
+        "specimen":  {
+            "US": {
+                "filename": str,
+                "sheetname": str
+            },
+            "CAN": {
+                "filename": str,
+                "sheetname": str                
+            }
+        },
+        "catch":  {
+            "US": {
+                "filename": str,
+                "sheetname": str
+            },
+            "CAN": {
+                "filename": str,
+                "sheetname": str                
+            }
+        },
+        "haul_to_transect":  {
+            "US": {
+                "filename": str,
+                "sheetname": str
+            },
+            "CAN": {
+                "filename": str,
+                "sheetname": str                
+            }
+        }
+    },
+    "stratification": {
+        "strata": {
+            "filename": str,
+            "sheetname": str                
+        },
+        "geo_strata": {
+            "filename": str,
+            "sheetname": [str]  
+        }
+    },
+    "NASC": {
+        "no_age1": {
+            "filename": str,
+            "sheetname": str  
+            },
+        "all_ages": {
+            "filename": str,
+            "sheetname": str              
+        }
+
+    },
+    "kriging": {
+        "mesh": {
+            "filename": str,
+            "sheetname": str  
+        },
+        "isobath_200m": {
+            "filename": str,
+            "sheetname": str  
+        },
+        "vario_krig_para": {
+            "filename": str,
+            "sheetname": str  
+        }
+    }
+}
+
+survey_year_config_params["kriging"]
+
 # `Survey` object data structure
 CONFIG_MAP = {
     "biological": {

--- a/echopop/utils/load.py
+++ b/echopop/utils/load.py
@@ -6,7 +6,7 @@ import pandas as pd
 import yaml
 from openpyxl import load_workbook
 
-from ..core import CONFIG_MAP, DATA_STRUCTURE, LAYER_NAME_MAP, CONFIG_DATA_API, CONFIG_INIT_API
+from ..core import CONFIG_DATA_API, CONFIG_INIT_API, CONFIG_MAP, DATA_STRUCTURE, LAYER_NAME_MAP
 
 
 def load_configuration(init_config_path: Path, survey_year_config_path: Path):
@@ -579,10 +579,12 @@ def prepare_input_data(input_dict: dict, configuration_dict: dict):
     # Return updated dictionaries
     return input_dict, configuration_dict
 
+
 def validate_config_structure(yaml_data, config_spec):
     """
     Validate configuration YAML dictionary structure and entry types
     """
+
     # Helper function for validating dictionary key names/structure
     def validate_dict(data, spec, path=""):
         for key, value in spec.items():
@@ -590,26 +592,32 @@ def validate_config_structure(yaml_data, config_spec):
             if key == "ANY":
                 # If the spec key is "ANY", check all keys in the data against the "ANY" spec
                 if not isinstance(data, dict):
-                    raise ValueError(f"Expected a dictionary at {current_path}, got {type(data).__name__}")
+                    raise ValueError(
+                        f"Expected a dictionary at {current_path}, got {type(data).__name__}"
+                    )
                 for sub_key in data:
                     validate_value(data[sub_key], spec[key], f"{current_path}.{sub_key}")
             else:
                 if key not in data:
                     raise KeyError(f"Missing key: {current_path}")
                 validate_value(data[key], value, current_path)
-    
+
     # Helper function for parsing values entered at different points throughout the dictionary
     def validate_value(data, spec, path):
         if isinstance(spec, dict):
             validate_dict(data, spec, path)
         elif isinstance(spec, type):
             if not is_valid_type(data, spec):
-                raise TypeError(f"Expected type {spec.__name__} at {path}, got {type(data).__name__}")
+                raise TypeError(
+                    f"Expected type {spec.__name__} at {path}, got {type(data).__name__}"
+                )
         elif isinstance(spec, list):
             if not isinstance(data, list):
                 raise TypeError(f"Expected a list at {path}, got {type(data).__name__}")
             if len(spec) != 1:
-                raise ValueError(f"Spec list at {path} should contain exactly one type element, got {spec}")
+                raise ValueError(
+                    f"Spec list at {path} should contain exactly one type element, got {spec}"
+                )
             for index, item in enumerate(data):
                 validate_value(item, spec[0], f"{path}[{index}]")
         else:


### PR DESCRIPTION
This relates to Issue #125 and implements a new function (`validate_config_structure`) that iteratively parses through the imported entries from the configuration YAML files to assess 1) the correct key names and 2) that the values/inputs are of the expected datatypes. 