### PR TITLE
Update default `crop_method` value (for mesh)

### DIFF
--- a/docs/example_notebooks/example_echopop_workflow.ipynb
+++ b/docs/example_notebooks/example_echopop_workflow.ipynb
@@ -71,7 +71,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'provenance': {'date': '2024-09-05 13:52:39', 'imported_datasets': set()}}\n"
+      "{'provenance': {'date': '2024-09-09 09:24:56', 'imported_datasets': set()}}\n"
      ]
     }
    ],
@@ -1301,14 +1301,14 @@
    "source": [
     "`Survey.kriging_analysis(...)` computes the kriged estimates for the target variable via ordinary kriging with an adaptive search radius. The arguments to `Survey.kriging_analysis(...)` include:\n",
     "* `coordinate_transform (boolean)`: when `True`, the transect and mesh longitude/latitude coordinates are transformed to a standardized format as x/y (default: `True`)\n",
-    "* `crop_method ('interpolation', 'convex_hull')`: when `extrapolate = False`, this determines the method used for cropping the kriging mesh. Setting `crop_method = 'interpolation'` (*default*) resamples the latitudinal resolution of the mesh grid and interpolates over the extent of the eastern and western endpoints of each transect line. This is conducted in a piece-wise fashion to account for the island of Haida Gwaii. Setting `crop_method = 'convex_hull'` uses a polygon-based approach for cropping the mesh grid based on the survey extent.\n",
+    "* `crop_method ('transect_ends', 'convex_hull')`: when `extrapolate = False`, this determines the method used for cropping the kriging mesh. Setting `crop_method = 'transect_ends'` (*default*) resamples the latitudinal resolution of the mesh grid and interpolates over the extent of the eastern and western endpoints of each transect line. This is conducted in a piece-wise fashion to account for the island of Haida Gwaii. Setting `crop_method = 'convex_hull'` uses a polygon-based approach for cropping the mesh grid based on the survey extent.\n",
     "* `extrapolate(boolean)`: when `True`, the entire kriging mesh is used. Otherwise, different methods are used to crop the kriging mesh to limit extrapolation beyond the extent of the survey transects. \n",
     "* `stratum ('ks','inpfc')`: the stratum used for mapping the defined kriged `variable` (default: `'ks'`) \n",
     "* `variable(string)`: the data variable that will be used for the kriging analysis (default: `'biomass_density'`)\n",
     "* `verbose (boolean)`: dialogue messages will appear in the console including a summary report of the results when this is set to `True` (default: `True`)\n",
     "\n",
     "There are also analysis-specific optional arguments that are used depending on how `crop_method` is defined:\n",
-    "* When `crop_method = 'interpolation'`:\n",
+    "* When `crop_method = 'transect_ends'`:\n",
     "  * `latitude_resolution (float)`: the updated latitudinal resolution (**in nmi**) used for interpolation\n",
     "* When `crop_method = 'convex_hull'`:\n",
     "  * `mesh_buffer_distance`: this is a dilation factor (**in nmi**) that expands/buffers the extent of the polygon defining the survey extent (default: `1.25`)\n",
@@ -1323,7 +1323,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -1345,22 +1345,22 @@
       "| Age-1 fish excluded: True\n",
       "| Stratum definition: KS\n",
       "| Mesh extrapolation: False\n",
-      "    Mesh cropping method: Interpolation\n",
+      "    Mesh cropping method: Transect ends\n",
       "| Mesh and transect coordinate standardization: True\n",
       "--------------------------------\n",
       "GENERAL RESULTS\n",
       "--------------------------------\n",
-      "| Mean biomassdensity: 27807.11 kg/nmi^2\n",
-      "| Total survey biomass estimate: 1644.45 kmt\n",
-      "| Mean mesh sample CV: 0.0241\n",
-      "| Overall survey CV: 0.0269\n",
+      "| Mean biomassdensity: 27804.61 kg/nmi^2\n",
+      "| Total survey biomass estimate: 1644.31 kmt\n",
+      "| Mean mesh sample CV: 0.0239\n",
+      "| Overall survey CV: 0.0268\n",
       "| Total area coverage: 58186.9 nmi^2\n",
       "--------------------------------\n"
      ]
     }
    ],
    "source": [
-    "survey.kriging_analysis( bearing_tolerance = 15.0 , coordinate_transform = True , crop_method = 'interpolation' , extrapolate = False , latitude_resolution = 1.25 , stratum = 'ks' , variable = 'biomass_density' , verbose = True )"
+    "survey.kriging_analysis( bearing_tolerance = 15.0 , coordinate_transform = True , crop_method = 'transect_ends' , extrapolate = False , latitude_resolution = 1.25 , stratum = 'ks' , variable = 'biomass_density' , verbose = True )"
    ]
   },
   {

--- a/echopop/spatial/mesh.py
+++ b/echopop/spatial/mesh.py
@@ -35,8 +35,8 @@ def crop_mesh(transect_data: pd.DataFrame, mesh_data: pd.DataFrame, settings_dic
 
     # Select and return cropped mesh depending on the cropping method
     # ---- Interpolation
-    if settings_dict["crop_method"] == "interpolation":
-        return interpolate_crop_method(transect_data.copy(), mesh, settings_dict)
+    if settings_dict["crop_method"] == "transect_ends":
+        return transect_ends_crop_method(transect_data.copy(), mesh, settings_dict)
     # ---- Convex hull
     elif settings_dict["crop_method"] == "convex_hull":
         return hull_crop_method(transect_data.copy(), mesh, settings_dict)
@@ -88,7 +88,7 @@ def hull_crop_method(transect_data: pd.DataFrame, mesh_data: pd.DataFrame, setti
     return mesh_gdf_masked.drop(columns="geometry")
 
 
-def interpolate_crop_method(
+def transect_ends_crop_method(
     transect_data: pd.DataFrame, mesh_data: pd.DataFrame, settings_dict: dict
 ):
     """

--- a/echopop/survey.py
+++ b/echopop/survey.py
@@ -533,7 +533,7 @@ class Survey:
         self,
         bearing_tolerance: float = 15.0,
         coordinate_transform: bool = True,
-        crop_method: Literal["interpolation", "convex_hull"] = "interpolation",
+        crop_method: Literal["transect_ends", "convex_hull"] = "transect_ends",
         extrapolate: bool = False,
         best_fit_variogram: bool = True,
         kriging_parameters: Optional[dict] = None,

--- a/echopop/utils/message.py
+++ b/echopop/utils/message.py
@@ -246,6 +246,8 @@ def kriging_results_msg(kriging_results_dict: pd.DataFrame, settings_dict: dict)
     mesh_crop = (
         settings_dict["crop_method"].capitalize() if not settings_dict["extrapolate"] else None
     )
+    # ---- Replace '_'
+    mesh_crop = mesh_crop.replace("_", " ")
 
     # Generate message output
     return print(


### PR DESCRIPTION
This swaps the default argument for `crop_method` within the `Survey.kriging_analysis(..., crop_method)` method. The default was previously `"interpolation"`. This has been updated to `"transect_ends"`. This change has been reflected in the accompanying `example_echopop_workflow.ipynb` example notebook as well. 