### PR TITLE
Small fix to `HaulTransectMap` validator

### DIFF
--- a/echopop/tests/test_data_loader_validation.py
+++ b/echopop/tests/test_data_loader_validation.py
@@ -1177,7 +1177,7 @@ def test_TransectRegionMap(input, exception):
                 "specimen": {"filename": "blargh", "sheetname": "sheet2"},
                 "catch": {"filename": "blorgh", "sheetname": "sheet3"},
             },
-            ValidationError,
+            None,
         ),
         (
             {

--- a/echopop/utils/validate_dict.py
+++ b/echopop/utils/validate_dict.py
@@ -403,7 +403,7 @@ class BiologicalFiles(BaseModel):
     length: Union[Dict[str, XLSXFiles], XLSXFiles]
     specimen: Union[Dict[str, XLSXFiles], XLSXFiles]
     catch: Union[Dict[str, XLSXFiles], XLSXFiles]
-    haul_to_transect: Optional[Union[Dict[str, XLSXFiles], XLSXFiles]]
+    haul_to_transect: Optional[Union[Dict[str, XLSXFiles], XLSXFiles]] = Field(default=None)
 
 
 class KrigingFiles(BaseModel):


### PR DESCRIPTION
When excluding the haul-to-transect map files and information from the dataset configuration file, an Error occurs indicating that the dataset is missing even though it isn't supposed to be required/mandatory. This is because a `Field(default=None)` was erroneously omitted from the validator. This has been added. 