### PR TITLE
Add references page to sidebar

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -39,4 +39,4 @@ parts:
 - caption: Help & references
   chapters:
   - file: api
-  - file: references
+  - file: zbibliography

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -36,6 +36,7 @@ parts:
   #   - file: algo1
   #   - file: algo2
   - file: glossary
-- caption: Help & reference
+- caption: Help & references
   chapters:
   - file: api
+  - file: references


### PR DESCRIPTION
This adds the references page to the side bar. It was previously rendered by not linked explicitly, and was only accessible via the stratification page.