### PR TITLE
Add kriging and NASC back-calculations to kriging analysis

### DIFF
--- a/docs/example_notebooks/report_generation.ipynb
+++ b/docs/example_notebooks/report_generation.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 1,
    "metadata": {
     "tags": [
      "remove_cell"
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,20 +59,43 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {
     "tags": [
      "remove-output"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The following report tables were generated:\n",
+      "   -'C:/Users/Brandyn/Documents/GitHub/EchoPro_data/Data/reports/aged_len_haul_counts_table.xlsx'\n",
+      "   -'C:/Users/Brandyn/Documents/GitHub/EchoPro_data/Data/reports/EchoPro_kriged_aged_output_0.xlsx'\n",
+      "   -'C:/Users/Brandyn/Documents/GitHub/EchoPro_data/Data/reports/EchoPro_kriged_aged_output_1.xlsx'\n",
+      "   -'C:/Users/Brandyn/Documents/GitHub/EchoPro_data/Data/reports/EchoPro_kriged_output_0.xlsx'\n",
+      "   -'C:/Users/Brandyn/Documents/GitHub/EchoPro_data/Data/reports/EchoPro_kriged_output_1.xlsx'\n",
+      "   -'C:/Users/Brandyn/Documents/GitHub/EchoPro_data/Data/reports/kriged_len_age_abundance_table.xlsx'\n",
+      "   -'C:/Users/Brandyn/Documents/GitHub/EchoPro_data/Data/reports/kriged_len_age_biomass_table.xlsx'\n",
+      "   -'C:/Users/Brandyn/Documents/GitHub/EchoPro_data/Data/reports/kriging_input.xlsx'\n",
+      "   -'C:/Users/Brandyn/Documents/GitHub/EchoPro_data/Data/reports/total_len_haul_counts_table.xlsx'\n",
+      "   -'C:/Users/Brandyn/Documents/GitHub/EchoPro_data/Data/reports/EchoPro_un-kriged_aged_output_0.xlsx'\n",
+      "   -'C:/Users/Brandyn/Documents/GitHub/EchoPro_data/Data/reports/EchoPro_un-kriged_aged_output_1.xlsx'\n",
+      "   -'C:/Users/Brandyn/Documents/GitHub/EchoPro_data/Data/reports/un-kriged_len_age_abundance_table.xlsx'\n",
+      "   -'C:/Users/Brandyn/Documents/GitHub/EchoPro_data/Data/reports/un-kriged_len_age_biomass_table.xlsx'\n",
+      "   -'C:/Users/Brandyn/Documents/GitHub/EchoPro_data/Data/reports/EchoPro_un-kriged_output_0.xlsx'\n",
+      "   -'C:/Users/Brandyn/Documents/GitHub/EchoPro_data/Data/reports/EchoPro_un-kriged_output_1.xlsx'\n"
+     ]
+    }
+   ],
    "source": [
     "survey.generate_reports()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 4,
    "metadata": {
     "tags": [
      "remove-input"
@@ -84,39 +107,42 @@
      "output_type": "stream",
      "text": [
       "The following report tables were generated:\n",
-      "    -'C:/Project/Data/Reports/aged_length_haul_counts_table.xlsx'\n",
-      "    -'C:/Project/Data/Reports/kriged_aged_biomass_mesh_dataframe.xlsx'\n",
-      "    -'C:/Project/Data/Reports/kriged_aged_biomass_reduced_mesh_dataframe.xlsx'\n",
-      "    -'C:/Project/Data/Reports/kriged_biomass_mesh_dataframe.xlsx'\n",
-      "    -'C:/Project/Data/Reports/kriged_biomass_mesh_reduced_dataframe.xlsx'\n",
-      "    -'C:/Project/Data/Reports/kriged_length_age_biomass_table.xlsx'\n",
-      "    -'C:/Project/Data/Reports/kriging_input_dataframe.xlsx'\n",
-      "    -'C:/Project/Data/Reports/total_length_haul_counts_table.xlsx'\n",
-      "    -'C:/Project/Data/Reports/transect_aged_biomass_dataframe.xlsx'\n",
-      "    -'C:/Project/Data/Reports/transect_aged_biomass_reduced_dataframe.xlsx'\n",
-      "    -'C:/Project/Data/Reports/transect_length_age_abundance_table.xlsx'\n",
-      "    -'C:/Project/Data/Reports/transect_length_age_biomass_table.xlsx'\n",
-      "    -'C:/Project/Data/Reports/transect_population_results_dataframe.xlsx'\n",
-      "\n"
+      "    -'C:/Project/Data/Reports/aged_len_haul_counts_table.xlsx'\n",
+      "    -'C:/Project/Data/Reports/EchoPro_kriged_aged_output_0.xlsx'\n",
+      "    -'C:/Project/Data/Reports/EchoPro_kriged_aged_output_1.xlsx'\n",
+      "    -'C:/Project/Data/Reports/EchoPro_kriged_output_0.xlsx'\n",
+      "    -'C:/Project/Data/Reports/EchoPro_kriged_output_1.xlsx'\n",
+      "    -'C:/Project/Data/Reports/kriged_len_age_abundance_table.xlsx'\n",
+      "    -'C:/Project/Data/Reports/kriged_len_age_biomass_table.xlsx'\n",
+      "    -'C:/Project/Data/Reports/kriging_input.xlsx'\n",
+      "    -'C:/Project/Data/Reports/total_len_haul_counts_table.xlsx'\n",
+      "    -'C:/Project/Data/Reports/EchoPro_un-kriged_aged_output_0.xlsx'\n",
+      "    -'C:/Project/Data/Reports/EchoPro_un-kriged_aged_output_1.xlsx'\n",
+      "    -'C:/Project/Data/Reports/un-kriged_len_age_abundance_table.xlsx'\n",
+      "    -'C:/Project/Data/Reports/un-kriged_len_age_biomass_table.xlsx'\n",
+      "    -'C:/Project/Data/Reports/EchoPro_un-kriged_output_0.xlsx'\n",
+      "    -'C:/Project/Data/Reports/EchoPro_un-kriged_output_1.xlsx'\n"
      ]
     }
    ],
    "source": [
     "print(\n",
     "    \"The following report tables were generated:\\n\",\n",
-    "    \"   -'C:/Project/Data/Reports/aged_length_haul_counts_table.xlsx'\\n\",\n",
-    "    \"   -'C:/Project/Data/Reports/kriged_aged_biomass_mesh_dataframe.xlsx'\\n\",\n",
-    "    \"   -'C:/Project/Data/Reports/kriged_aged_biomass_reduced_mesh_dataframe.xlsx'\\n\",\n",
-    "    \"   -'C:/Project/Data/Reports/kriged_biomass_mesh_dataframe.xlsx'\\n\",\n",
-    "    \"   -'C:/Project/Data/Reports/kriged_biomass_mesh_reduced_dataframe.xlsx'\\n\",\n",
-    "    \"   -'C:/Project/Data/Reports/kriged_length_age_biomass_table.xlsx'\\n\",\n",
-    "    \"   -'C:/Project/Data/Reports/kriging_input_dataframe.xlsx'\\n\",\n",
-    "    \"   -'C:/Project/Data/Reports/total_length_haul_counts_table.xlsx'\\n\",\n",
-    "    \"   -'C:/Project/Data/Reports/transect_aged_biomass_dataframe.xlsx'\\n\",\n",
-    "    \"   -'C:/Project/Data/Reports/transect_aged_biomass_reduced_dataframe.xlsx'\\n\",\n",
-    "    \"   -'C:/Project/Data/Reports/transect_length_age_abundance_table.xlsx'\\n\",\n",
-    "    \"   -'C:/Project/Data/Reports/transect_length_age_biomass_table.xlsx'\\n\",\n",
-    "    \"   -'C:/Project/Data/Reports/transect_population_results_dataframe.xlsx'\\n\"\n",
+    "    \"   -'C:/Project/Data/Reports/aged_len_haul_counts_table.xlsx'\\n\",\n",
+    "    \"   -'C:/Project/Data/Reports/EchoPro_kriged_aged_output_0.xlsx'\\n\",\n",
+    "    \"   -'C:/Project/Data/Reports/EchoPro_kriged_aged_output_1.xlsx'\\n\",\n",
+    "    \"   -'C:/Project/Data/Reports/EchoPro_kriged_output_0.xlsx'\\n\",\n",
+    "    \"   -'C:/Project/Data/Reports/EchoPro_kriged_output_1.xlsx'\\n\",\n",
+    "    \"   -'C:/Project/Data/Reports/kriged_len_age_abundance_table.xlsx'\\n\",\n",
+    "    \"   -'C:/Project/Data/Reports/kriged_len_age_biomass_table.xlsx'\\n\",\n",
+    "    \"   -'C:/Project/Data/Reports/kriging_input.xlsx'\\n\",\n",
+    "    \"   -'C:/Project/Data/Reports/total_len_haul_counts_table.xlsx'\\n\",\n",
+    "    \"   -'C:/Project/Data/Reports/EchoPro_un-kriged_aged_output_0.xlsx'\\n\",\n",
+    "    \"   -'C:/Project/Data/Reports/EchoPro_un-kriged_aged_output_1.xlsx'\\n\",\n",
+    "    \"   -'C:/Project/Data/Reports/un-kriged_len_age_abundance_table.xlsx'\\n\",\n",
+    "    \"   -'C:/Project/Data/Reports/un-kriged_len_age_biomass_table.xlsx'\\n\",\n",
+    "    \"   -'C:/Project/Data/Reports/EchoPro_un-kriged_output_0.xlsx'\\n\",\n",
+    "    \"   -'C:/Project/Data/Reports/EchoPro_un-kriged_output_1.xlsx'\"\n",
     ")"
    ]
   },
@@ -138,7 +164,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -148,9 +174,10 @@
       "The following report-types are available for export:\n",
       "   -'aged_length_haul_counts'\n",
       "   -'kriged_aged_biomass_mesh'\n",
-      "   -'kriged_biomass_mesh'\n",
-      "   -'kriged_length_age_biomass'\n",
       "   -'kriging_input'\n",
+      "   -'kriged_length_age_abundance'\n",
+      "   -'kriged_length_age_biomass'\n",
+      "   -'kriged_mesh_results'\n",
       "   -'total_length_haul_counts'\n",
       "   -'transect_aged_biomass'\n",
       "   -'transect_length_age_abundance'\n",
@@ -172,8 +199,8 @@
     "The `reports` argument for `Survey.generate_reports` is a `List` of possible report-types, which comprises the below options:\n",
     "- `\"aged_length_haul_counts\"`\n",
     "  - Table comprising distributions of counts from aged fish for each haul\n",
-    "- `\"kriged_biomass_mesh\"`\n",
-    "  - Dataframe comprising georeferenced kriged mesh results with biomass estimates\n",
+    "- `\"kriged_mesh_results\"`\n",
+    "  - Dataframe comprising georeferenced kriged mesh results with biomass estimates and back-calculated abundance and $\\textit{NASC}$ values\n",
     "- `\"kriged_aged_biomass_mesh\"`\n",
     "  - Dataframe comprising georeferenced kriged mesh results with biomass distributed across \n",
     "all age bins\n",
@@ -181,6 +208,8 @@
     "  - Dataframe comprising georeferenced abundance, biomass, and NASC values that can be used \n",
     "for the kriging analysis. Note that only the 'biomass' column is currently used within \n",
     "`Echopop`\n",
+    "- `\"kriged_length_age_abundance\"`\n",
+    "  - Table comprising (back-calculated) kriged abundance estimates distributed over age and length bins\n",
     "- `\"kriged_length_age_biomass\"`\n",
     "  - Table comprising kriged biomass estimates distributed over age and length bins\n",
     "- `\"transect_aged_biomass\"`\n",
@@ -200,20 +229,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {
     "tags": [
      "remove-output"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The following report tables were generated:\n",
+      "   -'C:/Users/Brandyn/Documents/GitHub/EchoPro_data/Data/reports/aged_len_haul_counts_table.xlsx'\n"
+     ]
+    }
+   ],
    "source": [
     "survey.generate_reports(reports=[\"aged_length_haul_counts\"])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 7,
    "metadata": {
     "tags": [
      "remove-input"
@@ -225,7 +263,7 @@
      "output_type": "stream",
      "text": [
       "The following report tables were generated:\n",
-      "    -'C:/Project/Data/Reports/aged_length_haul_counts_table.xlsx'\n",
+      "    -'C:/Project/Data/Reports/aged_len_haul_counts_table.xlsx'\n",
       "\n"
      ]
     }
@@ -233,7 +271,7 @@
    "source": [
     "print(\n",
     "    \"The following report tables were generated:\\n\",\n",
-    "    \"   -'C:/Project/Data/Reports/aged_length_haul_counts_table.xlsx'\\n\"\n",
+    "    \"   -'C:/Project/Data/Reports/aged_len_haul_counts_table.xlsx'\\n\"\n",
     ")"
    ]
   },
@@ -246,13 +284,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {
     "tags": [
      "remove-output"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The following report tables were generated:\n",
+      "   -'C:/Users/Brandyn/Documents/GitHub/EchoPro_data/Data/reports/aged_len_haul_counts_table.xlsx'\n",
+      "   -'C:/Users/Brandyn/Documents/GitHub/EchoPro_data/Data/reports/kriging_input.xlsx'\n"
+     ]
+    }
+   ],
    "source": [
     "\n",
     "survey.generate_reports(reports=[\"aged_length_haul_counts\", \"kriging_input\"])"
@@ -260,7 +308,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 9,
    "metadata": {
     "tags": [
      "remove-input"
@@ -272,8 +320,8 @@
      "output_type": "stream",
      "text": [
       "The following report tables were generated:\n",
-      "    -'C:/Project/Data/Reports/aged_length_haul_counts_table.xlsx'\n",
-      "    -'C:/Project/Data/Reports/kriging_input_dataframe.xlsx'\n",
+      "    -'C:/Project/Data/Reports/aged_len_haul_counts_table.xlsx'\n",
+      "    -'C:/Project/Data/Reports/kriging_input.xlsx'\n",
       "\n"
      ]
     }
@@ -281,8 +329,8 @@
    "source": [
     "print(\n",
     "    \"The following report tables were generated:\\n\",\n",
-    "    \"   -'C:/Project/Data/Reports/aged_length_haul_counts_table.xlsx'\\n\",\n",
-    "    \"   -'C:/Project/Data/Reports/kriging_input_dataframe.xlsx'\\n\",\n",
+    "    \"   -'C:/Project/Data/Reports/aged_len_haul_counts_table.xlsx'\\n\",\n",
+    "    \"   -'C:/Project/Data/Reports/kriging_input.xlsx'\\n\",\n",
     ")"
    ]
   },
@@ -295,20 +343,43 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {
     "tags": [
      "remove-output"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The following report tables were generated:\n",
+      "   -'C:/Users/Brandyn/Documents/GitHub/EchoPro_data/Data/reports/aged_len_haul_counts_table.xlsx'\n",
+      "   -'C:/Users/Brandyn/Documents/GitHub/EchoPro_data/Data/reports/EchoPro_kriged_aged_output_0.xlsx'\n",
+      "   -'C:/Users/Brandyn/Documents/GitHub/EchoPro_data/Data/reports/EchoPro_kriged_aged_output_1.xlsx'\n",
+      "   -'C:/Users/Brandyn/Documents/GitHub/EchoPro_data/Data/reports/kriging_input.xlsx'\n",
+      "   -'C:/Users/Brandyn/Documents/GitHub/EchoPro_data/Data/reports/kriged_len_age_abundance_table.xlsx'\n",
+      "   -'C:/Users/Brandyn/Documents/GitHub/EchoPro_data/Data/reports/kriged_len_age_biomass_table.xlsx'\n",
+      "   -'C:/Users/Brandyn/Documents/GitHub/EchoPro_data/Data/reports/EchoPro_kriged_output_0.xlsx'\n",
+      "   -'C:/Users/Brandyn/Documents/GitHub/EchoPro_data/Data/reports/EchoPro_kriged_output_1.xlsx'\n",
+      "   -'C:/Users/Brandyn/Documents/GitHub/EchoPro_data/Data/reports/total_len_haul_counts_table.xlsx'\n",
+      "   -'C:/Users/Brandyn/Documents/GitHub/EchoPro_data/Data/reports/EchoPro_un-kriged_aged_output_0.xlsx'\n",
+      "   -'C:/Users/Brandyn/Documents/GitHub/EchoPro_data/Data/reports/EchoPro_un-kriged_aged_output_1.xlsx'\n",
+      "   -'C:/Users/Brandyn/Documents/GitHub/EchoPro_data/Data/reports/un-kriged_len_age_abundance_table.xlsx'\n",
+      "   -'C:/Users/Brandyn/Documents/GitHub/EchoPro_data/Data/reports/un-kriged_len_age_biomass_table.xlsx'\n",
+      "   -'C:/Users/Brandyn/Documents/GitHub/EchoPro_data/Data/reports/EchoPro_un-kriged_output_0.xlsx'\n",
+      "   -'C:/Users/Brandyn/Documents/GitHub/EchoPro_data/Data/reports/EchoPro_un-kriged_output_1.xlsx'\n"
+     ]
+    }
+   ],
    "source": [
     "survey.generate_reports(reports=report_list)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 11,
    "metadata": {
     "tags": [
      "remove-input"
@@ -320,39 +391,42 @@
      "output_type": "stream",
      "text": [
       "The following report tables were generated:\n",
-      "    -'C:/Project/Data/Reports/aged_length_haul_counts_table.xlsx'\n",
-      "    -'C:/Project/Data/Reports/kriged_aged_biomass_mesh_dataframe.xlsx'\n",
-      "    -'C:/Project/Data/Reports/kriged_aged_biomass_reduced_mesh_dataframe.xlsx'\n",
-      "    -'C:/Project/Data/Reports/kriged_biomass_mesh_dataframe.xlsx'\n",
-      "    -'C:/Project/Data/Reports/kriged_biomass_mesh_reduced_dataframe.xlsx'\n",
-      "    -'C:/Project/Data/Reports/kriged_length_age_biomass_table.xlsx'\n",
-      "    -'C:/Project/Data/Reports/kriging_input_dataframe.xlsx'\n",
-      "    -'C:/Project/Data/Reports/total_length_haul_counts_table.xlsx'\n",
-      "    -'C:/Project/Data/Reports/transect_aged_biomass_dataframe.xlsx'\n",
-      "    -'C:/Project/Data/Reports/transect_aged_biomass_reduced_dataframe.xlsx'\n",
-      "    -'C:/Project/Data/Reports/transect_length_age_abundance_table.xlsx'\n",
-      "    -'C:/Project/Data/Reports/transect_length_age_biomass_table.xlsx'\n",
-      "    -'C:/Project/Data/Reports/transect_population_results_dataframe.xlsx'\n",
-      "\n"
+      "    -'C:/Project/Data/Reports/aged_len_haul_counts_table.xlsx'\n",
+      "    -'C:/Project/Data/Reports/EchoPro_kriged_aged_output_0.xlsx'\n",
+      "    -'C:/Project/Data/Reports/EchoPro_kriged_aged_output_1.xlsx'\n",
+      "    -'C:/Project/Data/Reports/EchoPro_kriged_output_0.xlsx'\n",
+      "    -'C:/Project/Data/Reports/EchoPro_kriged_output_1.xlsx'\n",
+      "    -'C:/Project/Data/Reports/kriged_len_age_abundance_table.xlsx'\n",
+      "    -'C:/Project/Data/Reports/kriged_len_age_biomass_table.xlsx'\n",
+      "    -'C:/Project/Data/Reports/kriging_input.xlsx'\n",
+      "    -'C:/Project/Data/Reports/total_len_haul_counts_table.xlsx'\n",
+      "    -'C:/Project/Data/Reports/EchoPro_un-kriged_aged_output_0.xlsx'\n",
+      "    -'C:/Project/Data/Reports/EchoPro_un-kriged_aged_output_1.xlsx'\n",
+      "    -'C:/Project/Data/Reports/un-kriged_len_age_abundance_table.xlsx'\n",
+      "    -'C:/Project/Data/Reports/un-kriged_len_age_biomass_table.xlsx'\n",
+      "    -'C:/Project/Data/Reports/EchoPro_un-kriged_output_0.xlsx'\n",
+      "    -'C:/Project/Data/Reports/EchoPro_un-kriged_output_1.xlsx'\n"
      ]
     }
    ],
    "source": [
     "print(\n",
     "    \"The following report tables were generated:\\n\",\n",
-    "    \"   -'C:/Project/Data/Reports/aged_length_haul_counts_table.xlsx'\\n\",\n",
-    "    \"   -'C:/Project/Data/Reports/kriged_aged_biomass_mesh_dataframe.xlsx'\\n\",\n",
-    "    \"   -'C:/Project/Data/Reports/kriged_aged_biomass_reduced_mesh_dataframe.xlsx'\\n\",\n",
-    "    \"   -'C:/Project/Data/Reports/kriged_biomass_mesh_dataframe.xlsx'\\n\",\n",
-    "    \"   -'C:/Project/Data/Reports/kriged_biomass_mesh_reduced_dataframe.xlsx'\\n\",\n",
-    "    \"   -'C:/Project/Data/Reports/kriged_length_age_biomass_table.xlsx'\\n\",\n",
-    "    \"   -'C:/Project/Data/Reports/kriging_input_dataframe.xlsx'\\n\",\n",
-    "    \"   -'C:/Project/Data/Reports/total_length_haul_counts_table.xlsx'\\n\",\n",
-    "    \"   -'C:/Project/Data/Reports/transect_aged_biomass_dataframe.xlsx'\\n\",\n",
-    "    \"   -'C:/Project/Data/Reports/transect_aged_biomass_reduced_dataframe.xlsx'\\n\",\n",
-    "    \"   -'C:/Project/Data/Reports/transect_length_age_abundance_table.xlsx'\\n\",\n",
-    "    \"   -'C:/Project/Data/Reports/transect_length_age_biomass_table.xlsx'\\n\",\n",
-    "    \"   -'C:/Project/Data/Reports/transect_population_results_dataframe.xlsx'\\n\"\n",
+    "    \"   -'C:/Project/Data/Reports/aged_len_haul_counts_table.xlsx'\\n\",\n",
+    "    \"   -'C:/Project/Data/Reports/EchoPro_kriged_aged_output_0.xlsx'\\n\",\n",
+    "    \"   -'C:/Project/Data/Reports/EchoPro_kriged_aged_output_1.xlsx'\\n\",\n",
+    "    \"   -'C:/Project/Data/Reports/EchoPro_kriged_output_0.xlsx'\\n\",\n",
+    "    \"   -'C:/Project/Data/Reports/EchoPro_kriged_output_1.xlsx'\\n\",\n",
+    "    \"   -'C:/Project/Data/Reports/kriged_len_age_abundance_table.xlsx'\\n\",\n",
+    "    \"   -'C:/Project/Data/Reports/kriged_len_age_biomass_table.xlsx'\\n\",\n",
+    "    \"   -'C:/Project/Data/Reports/kriging_input.xlsx'\\n\",\n",
+    "    \"   -'C:/Project/Data/Reports/total_len_haul_counts_table.xlsx'\\n\",\n",
+    "    \"   -'C:/Project/Data/Reports/EchoPro_un-kriged_aged_output_0.xlsx'\\n\",\n",
+    "    \"   -'C:/Project/Data/Reports/EchoPro_un-kriged_aged_output_1.xlsx'\\n\",\n",
+    "    \"   -'C:/Project/Data/Reports/un-kriged_len_age_abundance_table.xlsx'\\n\",\n",
+    "    \"   -'C:/Project/Data/Reports/un-kriged_len_age_biomass_table.xlsx'\\n\",\n",
+    "    \"   -'C:/Project/Data/Reports/EchoPro_un-kriged_output_0.xlsx'\\n\",\n",
+    "    \"   -'C:/Project/Data/Reports/EchoPro_un-kriged_output_1.xlsx'\"\n",
     ")"
    ]
   },
@@ -365,20 +439,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {
     "tags": [
      "remove-output"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The following requested reports do not match available report-types (use `.report_options()` for a complete list/print-out of available reports):\n",
+      "   -'tranect_population_results'\n",
+      "The following report tables were generated:\n",
+      "   -'C:/Users/Brandyn/Documents/GitHub/EchoPro_data/Data/reports/aged_len_haul_counts_table.xlsx'\n"
+     ]
+    }
+   ],
    "source": [
     "survey.generate_reports(reports=[\"aged_length_haul_counts\", \"tranect_population_results\"])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 13,
    "metadata": {
     "tags": [
      "remove-input"
@@ -392,7 +477,7 @@
       "The following requested reports do not match available report-types (use `.report_options()` for a complete list/print-out of available reports):\n",
       "    -'tranect_population_results'\n",
       " The following report tables were generated:\n",
-      "    -'C:/Project/Data/Reports/aged_length_haul_counts_table.xlsx'\n",
+      "    -'C:/Project/Data/Reports/aged_len_haul_counts_table.xlsx'\n",
       "\n"
      ]
     }
@@ -403,7 +488,7 @@
     "    \"for a complete list/print-out of available reports):\\n\",\n",
     "    \"   -'tranect_population_results'\\n\",\n",
     "    \"The following report tables were generated:\\n\",\n",
-    "    \"   -'C:/Project/Data/Reports/aged_length_haul_counts_table.xlsx'\\n\",    \n",
+    "    \"   -'C:/Project/Data/Reports/aged_len_haul_counts_table.xlsx'\\n\",    \n",
     ")"
    ]
   },
@@ -426,17 +511,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {
     "tags": [
      "remove-input"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The following report tables were generated:\n",
+      "    -'C:/Project/Output/Reports/aged_len_haul_counts_table.xlsx'\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "print(\n",
     "    \"The following report tables were generated:\\n\",\n",
-    "    \"   -'C:/Project/Output/Reports/aged_length_haul_counts_table.xlsx'\\n\"\n",
+    "    \"   -'C:/Project/Output/Reports/aged_len_haul_counts_table.xlsx'\\n\"\n",
     ")"
    ]
   },
@@ -520,7 +615,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 16,
    "metadata": {
     "tags": [
      "remove-input"
@@ -532,7 +627,7 @@
      "output_type": "stream",
      "text": [
       "The following report tables were generated:\n",
-      "    -'C:/Project/Output/Reports/aged_length_haul_counts_table.xlsx'\n",
+      "    -'C:/Project/Output/Reports/aged_len_haul_counts_table.xlsx'\n",
       "\n"
      ]
     }
@@ -540,7 +635,7 @@
    "source": [
     "print(\n",
     "    \"The following report tables were generated:\\n\",\n",
-    "    \"   -'C:/Project/Output/Reports/aged_length_haul_counts_table.xlsx'\\n\"\n",
+    "    \"   -'C:/Project/Output/Reports/aged_len_haul_counts_table.xlsx'\\n\"\n",
     ")"
    ]
   },

--- a/echopop/analysis.py
+++ b/echopop/analysis.py
@@ -8,6 +8,8 @@ import warnings
 import numpy as np
 import pandas as pd
 
+from typing import Any, Dict
+
 from .acoustics import aggregate_sigma_bs, nasc_to_biomass
 from .biology import (
     distribute_length_age,
@@ -460,12 +462,87 @@ def krige(input_dict: dict, analysis_dict: dict, settings_dict: dict) -> tuple[p
     )
 
     # Stratified the kriging mesh
-    kriged_results["mesh_results_df"] = stratify_mesh(
+    mesh_results = stratify_mesh(
         input_dict, kriged_results["mesh_results_df"], settings_dict
+    )
+
+    # Back-calculate abundance and NASC from kriged biomass
+    kriged_results["mesh_results_df"] = back_calculate_abundance_nasc(
+        mesh_results, analysis_dict["transect"], settings_dict
     )
 
     # Return kriged (interpolated) results
     return kriged_results, analysis_dict
+
+def back_calculate_abundance_nasc(mesh_results_df: pd.DataFrame, 
+                                  transect_dict: Dict[str, Any], 
+                                  settings_dict: Dict[str, Any]) -> pd.DataFrame: 
+    """
+    Back-calculate abundances and NASC from kriged biomass
+    """
+
+    # Get the stratum column name
+    stratum_col = settings_dict["stratum_name"]
+
+    # Set index for mesh results
+    mesh_results_df.set_index([stratum_col], inplace=True)
+
+    # Get the stratified mean weights
+    weight_strata = transect_dict["biology"]["weight"]["weight_stratum_df"].copy()
+    # ---- Sub-select and set index
+    weight_strata = (
+        weight_strata[weight_strata["sex"] == "all"]
+        .set_index([stratum_col]).reindex(mesh_results_df.index)
+    )
+
+    # Get the average `sigma_bs` per stratum
+    strata_mean_sigma_bs = (
+        transect_dict["acoustics"]["sigma_bs"]["strata_mean_df"]
+        .copy()
+    ).set_index([stratum_col]).reindex(mesh_results_df.index)
+
+    # Get the aged-unaged proportions
+    aged_unaged_proportions = (
+        transect_dict["biology"]["proportions"]["weight"]
+        ['aged_unaged_sex_weight_proportions_df'].copy()
+    ).set_index([stratum_col])
+
+    # Pivot the proportions into tables
+    # ---- Unaged
+    unaged_props = aged_unaged_proportions.pivot_table(
+        columns=["sex"], index=[stratum_col], values="weight_proportion_overall_unaged"
+    ).reindex(mesh_results_df.index)
+    # ---- Aged
+    aged_props = aged_unaged_proportions.pivot_table(
+        columns=["sex"], index=[stratum_col], values="weight_proportion_overall_aged"
+    ).reindex(mesh_results_df.index)
+
+    # Break up biomass into each sex
+    # ---- Female
+    mesh_results_df["biomass_female"] = (
+        mesh_results_df["biomass"] * unaged_props.loc[:, "female"]
+        + mesh_results_df["biomass"] * aged_props.loc[:, "female"]
+    )
+    # ---- Male
+    mesh_results_df["biomass_male"] = (
+        mesh_results_df["biomass"] * unaged_props.loc[:, "male"]
+        + mesh_results_df["biomass"] * aged_props.loc[:, "male"]        
+    )
+
+    # Compute abundance
+    # ---- All/female/male
+    mesh_results_df[["abundance", "abundance_female", "abundance_male"]] = (
+        mesh_results_df.loc[:, "biomass":"biomass_male"]
+        .div(weight_strata["average_weight"], axis=0)
+    )
+
+    # Compute NASC
+    mesh_results_df["nasc"] = (
+        mesh_results_df["abundance"] * strata_mean_sigma_bs["sigma_bs_mean"] * 4.0 * np.pi
+    )
+
+    # Return
+    return mesh_results_df.reset_index()
 
 
 def apportion_kriged_values(
@@ -489,10 +566,12 @@ def apportion_kriged_values(
     # ---- Extract stratum column name
     stratum_col = settings_dict["stratum_name"]
     # ---- Extract the biological variable (independent of area)
-    biology_col = settings_dict["variable"].replace("_density", "")
-    # ---- Sum the kriged values for each stratum
-    kriged_strata = kriged_mesh.groupby([stratum_col], observed=False)[biology_col].sum()
-
+    # biology_col = settings_dict["variable"].replace("_density", "")
+    # ---- Sum biomass for each stratum
+    summed_biomass = kriged_mesh.groupby([stratum_col], observed=False)["biomass"].sum()
+    # ---- Sum abundance for each stratum
+    summed_abundance = kriged_mesh.groupby([stratum_col], observed=False)["abundance"].sum()
+    
     # Extract the weight proportions from the analysis object
     proportions_dict = analysis_dict["transect"]["biology"]["proportions"]
     # ---- Aged
@@ -509,20 +588,30 @@ def apportion_kriged_values(
     unaged_sexed_apportioned = unaged_proportions.merge(aged_unaged_sex_proportions)
     # ---- Set index to stratum column
     unaged_sexed_apportioned.set_index([stratum_col], inplace=True)
-    # ---- Append the stratum-aggregated values
-    unaged_sexed_apportioned[f"{biology_col}_apportioned_unaged"] = (
+    # ---- Append the stratum-aggregated abundance values
+    unaged_sexed_apportioned["abundance_apportioned_unaged"] = (
         unaged_sexed_apportioned["weight_proportion"]
         * unaged_sexed_apportioned["weight_proportion_overall_unaged"]
-        * kriged_strata
+        * summed_abundance
+    )
+    # ---- Append the stratum-aggregated biomass values
+    unaged_sexed_apportioned["biomass_apportioned_unaged"] = (
+        unaged_sexed_apportioned["weight_proportion"]
+        * unaged_sexed_apportioned["weight_proportion_overall_unaged"]
+        * summed_biomass
     )
 
     # Distribute biological values over the overall proportions (i.e. relative to aged and unaged
     # fish) for aged fish
     # ---- Set index to stratum column
     aged_proportions.set_index([stratum_col], inplace=True)
-    # ---- Compute the distributed values
-    aged_proportions[f"{biology_col}_apportioned"] = (
-        aged_proportions["weight_proportion_overall"] * kriged_strata
+    # ---- Compute the distributed abundance values
+    aged_proportions["abundance_apportioned"] = (
+        aged_proportions["weight_proportion_overall"] * summed_abundance
+    ).fillna(0.0)
+    # ---- Compute the distributed biomass values
+    aged_proportions["biomass_apportioned"] = (
+        aged_proportions["weight_proportion_overall"] * summed_biomass
     ).fillna(0.0)
 
     # Distribute the aged biological distributions over unaged length distributions to estimate
@@ -531,64 +620,77 @@ def apportion_kriged_values(
     aged_pivot = aged_proportions.reset_index().pivot_table(
         index=["sex", "length_bin"],
         columns=["age_bin"],
-        values=f"{biology_col}_apportioned",
+        values=["abundance_apportioned", "biomass_apportioned"],
         aggfunc="sum",
         observed=False,
     )
     # ---- Calculate the total biomass values for each sex per length bin
-    aged_length_totals = aged_pivot.sum(axis=1).unstack("sex")
+    aged_length_biomass_totals = aged_pivot["biomass_apportioned"].sum(axis=1).unstack("sex")
     # ---- Pivot unaged data
     unaged_pivot = unaged_sexed_apportioned.reset_index().pivot_table(
         index=["length_bin"],
         columns=["sex"],
-        values=f"{biology_col}_apportioned_unaged",
+        values=["abundance_apportioned_unaged", "biomass_apportioned_unaged"],
         aggfunc="sum",
         observed=False,
     )
-    # ---- Calculate the new unaged biological values distributed over age
-    unaged_apportioned_values = (
-        unaged_pivot * aged_pivot.unstack("sex") / aged_length_totals
+    # ---- Calculate the new unaged biomass values distributed over age
+    unaged_apportioned_biomass_values = (
+        unaged_pivot["biomass_apportioned_unaged"]  
+        * aged_pivot.unstack("sex")["biomass_apportioned"] / aged_length_biomass_totals
     ).fillna(0)
 
     # Imputation is required when unaged values are present but aged values are absent at shared
     # length bins! This requires an augmented implementation to address this accordingly
-    kriged_table = impute_kriged_values(
-        aged_pivot, unaged_pivot, aged_length_totals, unaged_apportioned_values, settings_dict
-    )
-    # ---- Duplicate so there is an 'all' category
-    kriged_full_table = pd.concat([kriged_table, kriged_table.copy().assign(sex="all")])
-    # ---- Consolidate
-    kriging_full_table = (
-        kriged_full_table.groupby(["length_bin", "age_bin", "sex"], observed=False)[
-            f"{biology_col}_apportioned"
-        ]
-        .sum()
-        .reset_index(name=f"{biology_col}_apportioned")
+    # ---- Biomass
+    kriged_full_table = impute_kriged_values(
+        aged_pivot["biomass_apportioned"], 
+        unaged_pivot["biomass_apportioned_unaged"],
+        aged_length_biomass_totals, 
+        unaged_apportioned_biomass_values, 
+        settings_dict,
+        variable = "biomass",
     )
 
     # Additional reapportionment if age-1 fish are excluded
     if settings_dict["exclude_age1"]:
-        kriging_full_table = reallocate_kriged_age1(kriging_full_table, settings_dict)
+        # ---- Re-allocate biomass
+        kriging_full_table = reallocate_kriged_age1(kriged_full_table, 
+                                                    settings_dict,
+                                                    variable="biomass_apportioned")
+        # ---- Stack the aged-pivot table
+        aged_data = (
+            aged_pivot["abundance_apportioned"].stack().reset_index(name="abundance_apportioned")
+        )
+        # ---- Re-allocate abundance
+        aged_table = reallocate_kriged_age1(aged_data, 
+                                            settings_dict, 
+                                            variable="abundance_apportioned")
+        # ---- Re-pivot
+        aged_pivot["abundance_apportioned"] = aged_table.pivot_table(index=["sex", "length_bin"], 
+                                                                     columns=["age_bin"], 
+                                                                     values="abundance_apportioned",
+                                                                     observed=False)
         # ---- Validate that apportioning age-1 values over all adult values did not 'leak'
         # -------- Previous apportioned totals by sex
-        previous_totals = kriged_full_table.groupby(["sex"])[f"{biology_col}_apportioned"].sum()
+        previous_totals = kriged_full_table.groupby(["sex"])["biomass_apportioned"].sum()
         # -------- New apportioned totals by sex
-        new_totals = kriging_full_table.groupby(["sex"])[f"{biology_col}_apportioned"].sum()
+        new_totals = kriging_full_table.groupby(["sex"])["biomass_apportioned"].sum()
         # -------- Check (1 kg tolerance)
         if np.any((previous_totals - new_totals) > 1e-6):
             warnings.warn(
-                f"Apportioned kriged {biology_col} for age-1 not fully distributed over all age-2+ "
-                f"age bins."
+                "Apportioned kriged apportioned biomass for age-1 not fully distributed over all "
+                "age-2+ age bins."
             )
 
     # Check equality between original kriged estimates and (imputed) apportioned estimates
-    if (kriged_table[f"{biology_col}_apportioned"].sum() - kriged_strata.sum()) > 1e-6:
+    if (kriging_full_table["biomass_apportioned"].sum() - summed_biomass.sum()) > 1e-6:
         # ---- If not equal, generate warning
         warnings.warn(
-            f"Apportioned kriged {biology_col} does not equal the total kriged mesh "
-            f"{biology_col}! Check for cases where kriged values may only be present in aged "
-            f"(`self.results['kriging']['tables']['aged_tbl']`) or unaged ("
-            f"(`self.results['kriging']['tables']['unaged_tbl']`) distributions for each sex."
+            "Apportioned kriged apportioned biomass does not equal the total kriged mesh "
+            "apportioned biomass! Check for cases where kriged values may only be present in aged "
+            "(`self.results['kriging']['tables']['aged_tbl']`) or unaged ("
+            "(`self.results['kriging']['tables']['unaged_tbl']`) distributions for each sex."
         )
 
     # Return output

--- a/echopop/biology.py
+++ b/echopop/biology.py
@@ -1443,14 +1443,10 @@ def reallocate_kriged_age1(table: pd.DataFrame, settings_dict: dict, variable: s
     # Calculate the new contribution fractions
     # ---- Calculate the adjusted apportionment that will be distributed over the adult values
     data_table["adjustment"] = (
-       data_table["summed_sex_age1"]
-        * data_table[variable]
-        / data_table["summed_sex_adult"]
+        data_table["summed_sex_age1"] * data_table[variable] / data_table["summed_sex_adult"]
     )
     # ---- Apply the adjustment
-    data_table.loc[:, variable] = (
-        data_table.loc[:, variable] + data_table.loc[:, "adjustment"]
-    )
+    data_table.loc[:, variable] = data_table.loc[:, variable] + data_table.loc[:, "adjustment"]
     # ---- Index by age bins
     data_table.set_index("age_bin", inplace=True)
     # ---- Zero out the age-1 values

--- a/echopop/extensions/feat_report.py
+++ b/echopop/extensions/feat_report.py
@@ -622,13 +622,13 @@ class FEATReports:
                 Literal[
                     "aged_length_haul_counts",
                     "kriged_aged_biomass_mesh",
-                    "kriging_input",                    
+                    "kriging_input",
                     "kriged_length_age_abundance",
                     "kriged_length_age_biomass",
                     "kriged_mesh_results",
                     "total_length_haul_counts",
                     "transect_aged_biomass",
-                    "transect_length_age_abundance", 
+                    "transect_length_age_abundance",
                     "transect_length_age_biomass",
                     "transect_population_results",
                 ]
@@ -849,9 +849,7 @@ class FEATReports:
         # Get mesh results
         mesh_df = self.data.results["kriging"]["mesh_results_df"].copy()
         # Back-calculate the kriged standard deviation
-        mesh_df.loc[:, "kriged_sd"] = (
-            mesh_df.loc[:, "kriged_mean"] * mesh_df.loc[:, "sample_cv"]
-        )
+        mesh_df.loc[:, "kriged_sd"] = mesh_df.loc[:, "kriged_mean"] * mesh_df.loc[:, "sample_cv"]
         # ---- Set the index
         output_df = mesh_df.filter(
             [
@@ -902,30 +900,39 @@ class FEATReports:
         # ---- Stack
         aged_stk = aged_data.stack(future_stack=True).reset_index(name="abundance")
         # ---- Expand to include 'all'
-        full_aged_stk = pd.concat([aged_stk, 
-                                   aged_stk.groupby(["length_bin", "age_bin"], 
-                                                    observed=False)["abundance"]
-                                   .sum().reset_index().assign(sex="all")], 
-                                  ignore_index=True)
+        full_aged_stk = pd.concat(
+            [
+                aged_stk,
+                aged_stk.groupby(["length_bin", "age_bin"], observed=False)["abundance"]
+                .sum()
+                .reset_index()
+                .assign(sex="all"),
+            ],
+            ignore_index=True,
+        )
         # ---- Re-pivot
-        full_aged_pvt = full_aged_stk.pivot_table(index=["sex", "length_bin"], 
-                                                  columns=["age_bin"], 
-                                                  values="abundance", 
-                                                  observed=False)
+        full_aged_pvt = full_aged_stk.pivot_table(
+            index=["sex", "length_bin"], columns=["age_bin"], values="abundance", observed=False
+        )
 
         # Process the unaged data
         # ---- Stack
         unaged_stk = unaged_data.stack(future_stack=True).reset_index(name="abundance")
         # ---- Expand to include 'all'
-        full_unaged_stk = pd.concat([unaged_stk, 
-                                     unaged_stk.groupby(["length_bin"], 
-                                                        observed=False)["abundance"]
-                                     .sum().reset_index().assign(sex="all")], 
-                                    ignore_index=True)      
+        full_unaged_stk = pd.concat(
+            [
+                unaged_stk,
+                unaged_stk.groupby(["length_bin"], observed=False)["abundance"]
+                .sum()
+                .reset_index()
+                .assign(sex="all"),
+            ],
+            ignore_index=True,
+        )
         # ---- Re-pivot
-        full_unaged_pvt = full_unaged_stk.pivot_table(index=["sex", "length_bin"], 
-                                                      values="abundance", 
-                                                      observed=False)  
+        full_unaged_pvt = full_unaged_stk.pivot_table(
+            index=["sex", "length_bin"], values="abundance", observed=False
+        )
 
         # Repivot the datasets for each sex
         tables = {
@@ -956,10 +963,15 @@ class FEATReports:
         # Get the dataset
         dataset = self.data.results["kriging"]["tables"]["overall_apportionment_df"]
         # ---- Expand to include 'all'
-        dataset = pd.concat([dataset,
-                              dataset.groupby(["age_bin", "length_bin"],
-                                              observed=False)["biomass_apportioned"].sum()
-                              .reset_index().assign(sex="all")])
+        dataset = pd.concat(
+            [
+                dataset,
+                dataset.groupby(["age_bin", "length_bin"], observed=False)["biomass_apportioned"]
+                .sum()
+                .reset_index()
+                .assign(sex="all"),
+            ]
+        )
 
         # Initialize a pivot table from the dataset
         dataset_pvt = dataset.pivot_table(

--- a/echopop/extensions/feat_report.py
+++ b/echopop/extensions/feat_report.py
@@ -234,7 +234,12 @@ def repivot_table(
     """
 
     # Restack the data table
-    data_stk = age_length_dataframe.stack(future_stack=True).sum(axis=1).reset_index(name=variable)
+    data_stk = age_length_dataframe.stack(future_stack=True)
+    # ---- Sum across columns if strata are present
+    if any(["stratum" in name for name in age_length_dataframe.columns.names]):
+        data_stk = data_stk.sum(axis=1)
+    # ---- Reset index
+    data_stk = data_stk.reset_index(name=variable)
 
     # Concatenate unaged data, if needed
     if length_dataframe is not None:
@@ -271,7 +276,7 @@ def repivot_table(
     data_proc = data_pvt.rename_axis(columns=None, index=None)
 
     # Rename the unaged placeholder to "Unaged" and return
-    return data_proc.rename(columns={shifted_bin_mid: "Unaged"})
+    return data_proc.rename(columns={shifted_bin_mid: "Un-aged"})
 
 
 def pivot_aged_weight_proportions(
@@ -363,7 +368,7 @@ def write_aged_dataframe_report(
     wb = initialize_workbook(filepath)
 
     # Initialize
-    for sex in ["all", "female", "male"]:
+    for sex in ["male", "female", "all"]:
 
         # Add/overwrite the sheet
         ws = format_file_sheet(sex.capitalize(), wb)
@@ -513,9 +518,6 @@ class FEATReports:
             - *"aged_length_haul_counts"* \n
             Table comprising distributions of counts from aged fish for each haul
 
-            - *"kriged_biomass_mesh"* \n
-            Dataframe comprising georeferenced kriged mesh results with biomass estimates
-
             - *"kriged_aged_biomass_mesh"* \n
             Dataframe comprising georeferenced kriged mesh results with biomass distributed across
             all age bins
@@ -525,8 +527,14 @@ class FEATReports:
             for the kriging analysis. Note that only the 'biomass' column is currently used within
             `Echopop`
 
+            - *"kriged_length_age_abundance"* \n
+            Table comprising kriged abundance estimates distributed over age and length bins
+
             - *"kriged_length_age_biomass"* \n
             Table comprising kriged biomass estimates distributed over age and length bins
+
+            - *"kriged_mesh_results"* \n
+            Dataframe comprising georeferenced kriged mesh results with biomass estimates
 
             - *"transect_aged_biomass"* \n
             Dataframe comprising georeferenced along-transect biomass estimates with biomass
@@ -582,7 +590,7 @@ class FEATReports:
     >>> survey.kriging_analysis(variogram_parameters=dict(model=["exponential", "bessel"],
     ... n_lags=30), variable="biomass_density", verbose=False)
     >>> from echopop.extensions.FEATreports import FEATreports
-    >>> reports = ["aged_length_haul_counts", "kriged_biomass_mesh"]
+    >>> reports = ["aged_length_haul_counts", "kriged_mesh_results"]
     >>> FEATReports(survey, reports, save_directory="C:/Users/Data").generate()
     The following report tables were generated:
        -'C:/Users/Data/aged_length_haul_counts_table.xlsx'
@@ -614,12 +622,13 @@ class FEATReports:
                 Literal[
                     "aged_length_haul_counts",
                     "kriged_aged_biomass_mesh",
-                    "kriged_biomass_mesh",
+                    "kriging_input",                    
+                    "kriged_length_age_abundance",
                     "kriged_length_age_biomass",
-                    "kriging_input",
+                    "kriged_mesh_results",
                     "total_length_haul_counts",
                     "transect_aged_biomass",
-                    "transect_length_age_abundance",
+                    "transect_length_age_abundance", 
                     "transect_length_age_biomass",
                     "transect_population_results",
                 ]
@@ -633,7 +642,8 @@ class FEATReports:
             reports = [
                 "aged_length_haul_counts",
                 "kriged_aged_biomass_mesh",
-                "kriged_biomass_mesh",
+                "kriged_mesh_results",
+                "kriged_length_age_abundance",
                 "kriged_length_age_biomass",
                 "kriging_input",
                 "total_length_haul_counts",
@@ -827,7 +837,7 @@ class FEATReports:
         # Return the filepath name
         return filepath[0].as_posix(), filepath[1].as_posix()
 
-    def kriged_biomass_mesh_report(
+    def kriged_mesh_results_report(
         self,
         filename: str,
         **kwargs,
@@ -836,45 +846,22 @@ class FEATReports:
         # Get the stratum name
         stratum_name = self.data.analysis["settings"]["transect"]["stratum_name"]
 
-        # Get apportionment information
-        apportion_df = self.data.analysis["transect"]["biology"]["proportions"]["weight"][
-            "aged_unaged_sex_weight_proportions_df"
-        ].copy()
-        # ---- Pivot
-        apportion_pvt = apportion_df.pivot_table(index=["stratum_num"], columns=["sex"])
-        # ---- Compute the proportions across strata
-        stratum_prop = (
-            apportion_pvt["weight_proportion_overall_aged"]
-            + apportion_pvt["weight_proportion_overall_unaged"]
-        )
-
         # Get mesh results
         mesh_df = self.data.results["kriging"]["mesh_results_df"].copy()
-        # ---- Set the index
-        mesh_df.set_index(stratum_name, inplace=True)
-
-        # Merge the mesh and apportionment dataframes
-        merged_mesh = pd.merge(mesh_df, stratum_prop, left_index=True, right_index=True)
-        # ---- Propagate the proportions across biomass estimates
-        merged_mesh.loc[:, "female":"male"] = merged_mesh.loc[:, "female":"male"].mul(
-            merged_mesh["biomass"], axis=0
-        )
-        # ---- Rename the columns
-        merged_mesh.rename(
-            columns={"female": "biomass_female", "male": "biomass_male"}, inplace=True
-        )
-
         # Back-calculate the kriged standard deviation
-        merged_mesh.loc[:, "kriged_sd"] = (
-            merged_mesh.loc[:, "kriged_mean"] * merged_mesh.loc[:, "sample_cv"]
+        mesh_df.loc[:, "kriged_sd"] = (
+            mesh_df.loc[:, "kriged_mean"] * mesh_df.loc[:, "sample_cv"]
         )
-
-        # Update and filter the columns that will be exported
-        output_df = merged_mesh.reset_index().filter(
+        # ---- Set the index
+        output_df = mesh_df.filter(
             [
                 "latitude",
                 "longitude",
                 stratum_name,
+                "nasc",
+                "abundance",
+                "abundance_female",
+                "abundance_male",
                 "biomass",
                 "biomass_female",
                 "biomass_male",
@@ -897,6 +884,68 @@ class FEATReports:
         # Return the filepath name
         return filepath[0].as_posix(), filepath[1].as_posix()
 
+    def kriged_length_age_abundance_report(
+        self,
+        title: str,
+        filename: str,
+        **kwargs,
+    ):
+
+        # Get the dataset
+        dataset = self.data.results["kriging"]["tables"]
+        # ---- Aged data
+        aged_data = dataset["aged_tbl"]["abundance_apportioned"].copy(0)
+        # ---- Unaged data
+        unaged_data = dataset["unaged_tbl"]["abundance_apportioned_unaged"].copy()
+
+        # Process the aged data
+        # ---- Stack
+        aged_stk = aged_data.stack(future_stack=True).reset_index(name="abundance")
+        # ---- Expand to include 'all'
+        full_aged_stk = pd.concat([aged_stk, 
+                                   aged_stk.groupby(["length_bin", "age_bin"], 
+                                                    observed=False)["abundance"]
+                                   .sum().reset_index().assign(sex="all")], 
+                                  ignore_index=True)
+        # ---- Re-pivot
+        full_aged_pvt = full_aged_stk.pivot_table(index=["sex", "length_bin"], 
+                                                  columns=["age_bin"], 
+                                                  values="abundance", 
+                                                  observed=False)
+
+        # Process the unaged data
+        # ---- Stack
+        unaged_stk = unaged_data.stack(future_stack=True).reset_index(name="abundance")
+        # ---- Expand to include 'all'
+        full_unaged_stk = pd.concat([unaged_stk, 
+                                     unaged_stk.groupby(["length_bin"], 
+                                                        observed=False)["abundance"]
+                                     .sum().reset_index().assign(sex="all")], 
+                                    ignore_index=True)      
+        # ---- Re-pivot
+        full_unaged_pvt = full_unaged_stk.pivot_table(index=["sex", "length_bin"], 
+                                                      values="abundance", 
+                                                      observed=False)  
+
+        # Repivot the datasets for each sex
+        tables = {
+            sex: repivot_table(
+                age_length_dataframe=full_aged_pvt.loc[sex, :],
+                length_dataframe=full_unaged_pvt.loc[sex, :],
+                variable="abundance",
+            )
+            for sex in ["all", "male", "female"]
+        }
+
+        # Get filepath
+        filepath = self.save_directory / filename
+
+        # Write the *.xlsx sheet
+        write_age_length_table_report(tables, title, filepath)
+
+        # Return the filepath name
+        return filepath.as_posix()
+
     def kriged_length_age_biomass_report(
         self,
         title: str,
@@ -906,12 +955,17 @@ class FEATReports:
 
         # Get the dataset
         dataset = self.data.results["kriging"]["tables"]["overall_apportionment_df"]
+        # ---- Expand to include 'all'
+        dataset = pd.concat([dataset,
+                              dataset.groupby(["age_bin", "length_bin"],
+                                              observed=False)["biomass_apportioned"].sum()
+                              .reset_index().assign(sex="all")])
 
         # Initialize a pivot table from the dataset
         dataset_pvt = dataset.pivot_table(
             index=["sex", "length_bin"],
             columns=["age_bin"],
-            values=["biomass_apportioned"],
+            values="biomass_apportioned",
             aggfunc="sum",
             observed=False,
         )
@@ -1192,23 +1246,28 @@ class FEATReports:
                 "EchoPro_kriged_aged_output_1.xlsx",
             ),
         },
-        "kriged_biomass_mesh": {
-            "function": kriged_biomass_mesh_report,
+        "kriging_input": {
+            "function": kriging_input_report,
             "title": None,
-            "filename": (
-                "EchoPro_kriged_output_0.xlsx",
-                "EchoPro_kriged_output_1.xlsx",
-            ),
+            "filename": "kriging_input.xlsx",
+        },
+        "kriged_length_age_abundance": {
+            "function": kriged_length_age_abundance_report,
+            "title": "Kriged Acoustically Weighted Abundance ({SEX})",
+            "filename": "kriged_len_age_abundance_table.xlsx",
         },
         "kriged_length_age_biomass": {
             "function": kriged_length_age_biomass_report,
             "title": "Kriged Acoustically Weighted Biomass (mmt) ({SEX})",
             "filename": "kriged_len_age_biomass_table.xlsx",
         },
-        "kriging_input": {
-            "function": kriging_input_report,
+        "kriged_mesh_results": {
+            "function": kriged_mesh_results_report,
             "title": None,
-            "filename": "kriging_input.xlsx",
+            "filename": (
+                "EchoPro_kriged_output_0.xlsx",
+                "EchoPro_kriged_output_1.xlsx",
+            ),
         },
         "total_length_haul_counts": {
             "function": total_length_haul_counts_report,


### PR DESCRIPTION
This PR adds:

* Abundance and NASC back-calculations from kriged biomass estimates
* Adjustments to the reports output to include the (back-calculated) kriged abundance estimates distributed over length and age
* Minor order adjustment to sheets when partitioned by sex
* Adjustments to the reports example workbook 