### PR TITLE
Fix stratified and kriging analysis INPFC bugs

### DIFF
--- a/echopop/spatial/transect.py
+++ b/echopop/spatial/transect.py
@@ -70,8 +70,16 @@ def save_transect_coordinates(transect_data: pd.DataFrame, settings_dict: dict):
     # Get the correct haul and stratum names
     age_group_cols = settings_dict["age_group_columns"]
 
+    # Get stratum definition
+    stratum_def = settings_dict["stratum"]
+    
     # Get stratum column name
     stratum_col = settings_dict["stratum_name"]
+    # ---- Set up the column renaming scheme
+    if stratum_def == "inpfc":        
+        stratum_rename = "stratum_num"
+    else:
+        stratum_rename = stratum_col
 
     # Extract transect numbers, coordinates, and strata
     transect_data_extract = transect_data.filter(
@@ -88,7 +96,8 @@ def save_transect_coordinates(transect_data: pd.DataFrame, settings_dict: dict):
 
     # Rename the group-specific columns and return the output
     return transect_data_extract.rename(
-        columns={age_group_cols["haul_id"]: "haul_num", age_group_cols["stratum_id"]: stratum_col}
+        columns={age_group_cols["haul_id"]: "haul_num", 
+                 age_group_cols["stratum_id"]: stratum_rename}
     )
 
 

--- a/echopop/spatial/transect.py
+++ b/echopop/spatial/transect.py
@@ -72,11 +72,11 @@ def save_transect_coordinates(transect_data: pd.DataFrame, settings_dict: dict):
 
     # Get stratum definition
     stratum_def = settings_dict["stratum"]
-    
+
     # Get stratum column name
     stratum_col = settings_dict["stratum_name"]
     # ---- Set up the column renaming scheme
-    if stratum_def == "inpfc":        
+    if stratum_def == "inpfc":
         stratum_rename = "stratum_num"
     else:
         stratum_rename = stratum_col
@@ -96,8 +96,10 @@ def save_transect_coordinates(transect_data: pd.DataFrame, settings_dict: dict):
 
     # Rename the group-specific columns and return the output
     return transect_data_extract.rename(
-        columns={age_group_cols["haul_id"]: "haul_num", 
-                 age_group_cols["stratum_id"]: stratum_rename}
+        columns={
+            age_group_cols["haul_id"]: "haul_num",
+            age_group_cols["stratum_id"]: stratum_rename,
+        }
     )
 
 

--- a/echopop/survey.py
+++ b/echopop/survey.py
@@ -887,17 +887,13 @@ class Survey:
                 # ---- From `self.transect_analysis` settings
                 "exclude_age1": self.analysis["settings"]["transect"]["exclude_age1"],
                 "stratum": self.analysis["settings"]["transect"]["stratum"],
+                "stratum_name": self.analysis["settings"]["transect"]["stratum_name"],
             },
         )
 
         # Calculate additional keys for the settings
         self.analysis["settings"]["kriging"].update(
             {
-                "stratum_name": (
-                    "stratum_num"
-                    if self.analysis["settings"]["kriging"]["stratum"] == "ks"
-                    else "inpfc"
-                ),
                 "variogram_parameters": (
                     {
                         **self.input["statistics"]["variogram"]["model_config"],


### PR DESCRIPTION
This PR addresses #311 where errors were raised when running `Survey.stratified_analysis()` and `Survey.kriging_analysis` when inheriting the stratum definition (specifically INPFC) from `Survey.transect_analysis(stratum="inpfc")`. This required minor changes to how the stratum column name is internally stored within `Survey.analysis["settings"]` and removing a duplication bug when storing the transect data indices.