### PR TITLE
Update biodata ingestion

### DIFF
--- a/config_files/survey_year_2019_single_biodata_config.yml
+++ b/config_files/survey_year_2019_single_biodata_config.yml
@@ -1,0 +1,79 @@
+# This YAML file is a configuration file specifying
+# input filenames & some process parameter settings.
+# Relative file paths defined below are concatenated
+# with the data_root_dir path also set below.
+
+---
+##############################################################################
+# Parameters
+
+survey_year: 2019            # survey year being considered
+ship_id:
+  160:
+    survey: 201906
+    name: NOAA Ship Bell M Shimada
+    description: NOAA Fisheries Survey Vessel
+  584:
+    survey: 2019097
+    name: FV Nordic Pearl
+    description: Canadian Coast Guard
+    haul_offset: 200
+species:
+  text_code: pacific_hake    # target species for the survey year -- species name
+  number_code: 22500         # target species for the survey year -- numeric code
+CAN_haul_offset: 200         # The value to be added to the Canadian's haul number
+
+##############################################################################
+# Report generation
+###################
+# Where the reports are saved
+report_path: C:/Users/Brandyn/Documents/GitHub/EchoPro_data/Data/reports
+
+##############################################################################
+# Directory path that contains all input data needed
+
+data_root_dir: C:/Users/Brandyn Lucca/Documents/Data/echopop_2019
+# data_root_dir: C:/Users/Brandyn/Documents/GitHub/EchoPro_data/Data/
+
+##############################################################################
+# Input data files
+
+biological:
+  filename: Biological/1995-2023_biodata_redo.xlsx
+  sheetname:
+    catch: biodata_catch
+    length: biodata_length
+    specimen: biodata_specimen
+stratification:
+  strata:
+    # The two stratification types are found in two sheets: "Base KS" and "INPFC"
+    filename: Stratification/US_CAN strata 2019_final.xlsx
+    sheetname: Base KS
+  geo_strata:
+    # The two stratification types are found in two sheets: "stratification1" and "INPFC"
+    filename: Stratification/Stratification_geographic_Lat_2019_final.xlsx
+    sheetname: [INPFC , stratification1]
+NASC:
+  # NASC values
+  no_age1:
+    # file that excludes age1 values
+    # filename: Exports/US_CAN_NASC_2019_table_no_age1_test.xlsx
+    filename: Exports/US_CAN_detailsa_2019_table2y+_ALL_final - updated.xlsx
+    sheetname: Sheet1
+  all_ages:
+    # file that includes all ages
+    # filename: Exports/US_CAN_NASC_2019_table_all_ages_test.xlsx
+    filename: Exports/US_CAN_detailsa_2019_table1y+_ALL_final - updated.xlsx
+    sheetname: Sheet1
+kriging:
+  mesh:
+    filename: Kriging_files/Kriging_grid_files/krig_grid2_5nm_cut_centroids_2013.xlsx
+    sheetname: krigedgrid2_5nm_forChu
+  isobath_200m:
+    filename: Kriging_files/Kriging_grid_files/transformation_isobath_coordinates.xlsx
+    sheetname: Smoothing_EasyKrig
+  vario_krig_para:
+    # NOTE: This file is not currently used
+    filename: Kriging_files/default_vario_krig_settings_2019_US_CAN.xlsx
+    sheetname: Sheet1
+...

--- a/echopop/tests/test_data_loader_validation.py
+++ b/echopop/tests/test_data_loader_validation.py
@@ -11,6 +11,7 @@ from ..utils.validate import posfloat, posint, realposfloat
 from ..utils.validate_dict import (
     CONFIG_DATA_MODEL,
     CONFIG_INIT_MODEL,
+    BiologicalFile,
     BiologicalFiles,
     FileSettings,
     Geospatial,
@@ -321,7 +322,7 @@ def XLSXFile_fields() -> Dict[str, Any]:
             "frozen": None,
         },
         "sheetname": {
-            "annotation": Union[str, List[str]],
+            "annotation": Union[str, List[str], Dict[str, str]],
             "frozen": None,
         },
     }
@@ -2346,7 +2347,7 @@ def CONFIG_DATA_MODEL_fields() -> Dict[str, Any]:
             "frozen": None,
         },
         "biological": {
-            "annotation": BiologicalFiles,
+            "annotation": Union[BiologicalFile, BiologicalFiles],
             "frozen": None,
         },
         "stratification": {
@@ -2381,7 +2382,7 @@ def CONFIG_DATA_MODEL_fields() -> Dict[str, Any]:
             "frozen": None,
         },
         "ship_id": {
-            "annotation": Union[int, str, float, None],
+            "annotation": Union[int, str, float, Dict[Any, Any], None],
             "default": None,
             "frozen": None,
         },

--- a/echopop/utils/load.py
+++ b/echopop/utils/load.py
@@ -176,50 +176,41 @@ def load_dataset(
     # Data validation and import
     # ---- Iterate through known datasets and datalayers
     for dataset in list(expected_datasets):
-
-        for datalayer in [*configuration_dict[dataset].keys()]:
+        # ---- Define datalayers
+        if dataset == "biological":
+            if "filename" and "sheetname" in configuration_dict[dataset]:
+                datalayers = {
+                    k: {"filename": configuration_dict[dataset]["filename"], "sheetname": v}
+                    for k, v in configuration_dict[dataset]["sheetname"].items()
+                }
+        else:
+            datalayers = configuration_dict[dataset]
+        # ---- Iterate through
+        for datalayer, config_settings in datalayers.items():
 
             # Define validation settings from CONFIG_MAP
             validation_settings = DATASET_DF_MODEL[dataset][datalayer]
 
-            # Define configuration settings w/ file + sheet names
-            config_settings = configuration_dict[dataset][datalayer]
-
             # Create reference index of the dictionary path
             config_map = [dataset, datalayer]
 
-            # Create list of region id's associated with biodata (if applicable)
-            if dataset == "biological":
-                regions = configuration_dict[dataset][datalayer].keys()
-            else:
-                regions = [None]  # Use None for non-biological datasets
-
             # Create the file and sheetnames for the associated datasets
-            for region_id in regions:
-                if region_id is not None:
-                    # ---- Biological data
-                    file_name = data_root_directory / config_settings[region_id]["filename"]
-                    sheet_name = config_settings[region_id]["sheetname"]
-                    # ---- Update `config_map` to include region_id
-                    config_map = [dataset, datalayer, region_id]
-                else:
-                    # ---- All other datasets
-                    file_name = data_root_directory / config_settings["filename"]
-                    sheet_name = config_settings["sheetname"]
+            file_name = data_root_directory / config_settings["filename"]
+            sheet_name = config_settings["sheetname"]
 
-                # Ensure sheet_name is a list (to handle cases with multiple lists)
-                sheet_name = [sheet_name] if isinstance(sheet_name, str) else sheet_name
+            # Ensure sheet_name is a list (to handle cases with multiple lists)
+            sheet_name = [sheet_name] if isinstance(sheet_name, str) else sheet_name
 
-                # Validate data for each sheet
-                for sheets in sheet_name:
-                    read_validated_data(
-                        input_dict,
-                        configuration_dict,
-                        file_name,
-                        sheets,
-                        config_map,
-                        validation_settings,
-                    )
+            # Validate data for each sheet
+            for sheets in sheet_name:
+                read_validated_data(
+                    input_dict,
+                    configuration_dict,
+                    file_name,
+                    sheets,
+                    config_map,
+                    validation_settings,
+                )
 
     # If all files could be successfully read in, update the `imported_data` list
     imported_data = map_imported_datasets(input_dict)
@@ -271,13 +262,42 @@ def read_validated_data(
         df = validation_settings.validate_df(df_initial)
     else:
         # Read Excel file into memory -- this only reads in the required columns
-        df = pd.read_excel(file_name, sheet_name=sheet_name)
+        df_initial = pd.read_excel(file_name, sheet_name=sheet_name)
         # ---- Force the column names to be lower case
-        df.columns = df.columns.str.lower()
+        df_initial.columns = df_initial.columns.str.lower()
         # ---- Rename the columns
-        df.rename(columns=NAME_CONFIG, inplace=True)
+        df_initial.rename(columns=NAME_CONFIG, inplace=True)
+        # ---- Filter the dataset accordingly, if required
+        if "ship_id" in configuration_dict and config_map[0] == "biological":
+            # ---- Collect ship configuration
+            ship_config = configuration_dict["ship_id"]
+            # ---- Get ship IDs
+            ship_ids = [*ship_config.keys()]
+            # ---- Apply ship-based filter
+            if "ship_id" in df_initial.columns:
+                df_filtered = df_initial.loc[df_initial["ship_id"].isin(ship_ids)]
+            # ---- Collect survey IDs, if present
+            survey_ids = [
+                v["survey"] for v in configuration_dict["ship_id"].values() if "survey" in v
+            ]
+            # ---- Apply survey-based filter
+            if survey_ids and "survey" in df_initial.columns:
+                df_filtered = df_filtered.loc[df_filtered["survey"].isin(survey_ids)]
+            # ---- Collect haul offsets, if any are present
+            haul_offsets = {
+                k: v["haul_offset"]
+                for k, v in configuration_dict["ship_id"].items()
+                if "haul_offset" in v
+            }
+            # ---- Apply haul number offsets, if defined
+            if haul_offsets:
+                df_filtered["haul_num"] = df_filtered["haul_num"] + df_filtered["ship_id"].map(
+                    haul_offsets
+                ).fillna(0)
+        else:
+            df_filtered = df_initial.copy()
         # ---- Validate the dataframes
-        df = validation_settings.validate_df(df)
+        df = validation_settings.validate_df(df_filtered)
 
     # Assign the data to their correct data attributes/keys
     if LAYER_NAME_MAP[config_map[0]]["superlayer"] == []:
@@ -287,15 +307,7 @@ def read_validated_data(
 
     # Step 2: Determine whether the dataframe already exists
     if sub_attribute in ["biology", "statistics", "spatial"]:
-        if sub_attribute == "biology":
-            # Add US / CAN as a region index
-            df["region"] = config_map[2]
-
-            # Apply CAN haul number offset
-            if config_map[2] == "CAN":
-                df["haul_num"] += configuration_dict["CAN_haul_offset"]
-
-        # A single dataframe per entry is expected, so no other fancy operations are needed
+        # ---- A single dataframe per entry is expected, so no other fancy operations are needed
         if sheet_name.lower() == "inpfc":
             df_list = [input_dict[sub_attribute]["inpfc_strata_df"], df]
             input_dict[sub_attribute]["inpfc_strata_df"] = pd.concat(df_list)
@@ -313,8 +325,7 @@ def read_validated_data(
                 input_dict[sub_attribute][config_map[1] + "_df"] = pd.concat(df_list)
     # TODO: This can be refactored out
     elif sub_attribute == "acoustics":
-
-        # Toggle through including and excluding age-1
+        # ---- Toggle through including and excluding age-1
         if config_map[1] == "no_age1":
             df = df.rename(
                 columns={

--- a/echopop/utils/validate_dict.py
+++ b/echopop/utils/validate_dict.py
@@ -55,7 +55,7 @@ class XLSXFile(InputModel, title="*.xlsx file tree"):
     """
 
     filename: str
-    sheetname: Union[str, List[str]]
+    sheetname: Union[str, List[str], Dict[str, str]]
 
 
 class FileSettings(InputModel, title="parameter file settings"):
@@ -420,6 +420,45 @@ class CONFIG_INIT_MODEL(InputModel, arbitrary_types_allowed=True):
             return [posint(value) for value in v]
 
 
+class BiologicalSheets(InputModel, title="consolidated biological file input sheetnames"):
+    """
+    Consolidated biological data file input
+
+    Parameters
+    ----------
+    length:str
+       An *.xlsx sheet containing binned length data.
+    specimen: str
+        An *.xlsx sheet containing specimen biodata.
+    catch: str
+        An *.xlsx sheet containing catch/haul biological data.
+    """
+
+    length: str
+    specimen: str
+    catch: str
+
+
+class BiologicalFile(InputModel, title="consolidated biological file input"):
+    """
+    Consolidated biological data file input
+
+    Parameters
+    ----------
+    length: Union[Dict[str, XLSXFile], XLSXFile]
+        An *.xlsx file (or dictionary of files) containing binned length data.
+    specimen: Union[Dict[str, XLSXFile], XLSXFile]
+        An *.xlsx file (or dictionary of files) containing specimen biodata.
+    catch: Union[Dict[str, XLSXFile], XLSXFile]
+        An *.xlsx file (or dictionary of files) containing catch/haul biological data.
+    haul_to_transect: Union[Dict[str, XLSXFile], XLSXFile]
+        An *.xlsx file (or dictionary of files) containing haul-transect mapping data.
+    """
+
+    filename: str
+    sheetname: BiologicalSheets
+
+
 class BiologicalFiles(InputModel, title="biological file inputs"):
     """
     Biological data files
@@ -493,7 +532,7 @@ class CONFIG_DATA_MODEL(InputModel):
     """
 
     survey_year: int
-    biological: BiologicalFiles
+    biological: Union[BiologicalFile, BiologicalFiles]
     stratification: StratificationFiles
     NASC: Dict[str, XLSXFile]
     species: SpeciesDefinition
@@ -501,7 +540,7 @@ class CONFIG_DATA_MODEL(InputModel):
     report_path: Optional[str] = None
     data_root_dir: Optional[str] = None
     CAN_haul_offset: Optional[int] = None
-    ship_id: Optional[Union[int, str, float]] = None
+    ship_id: Optional[Union[int, str, float, Dict[Any, Any]]] = None
     export_regions: Optional[Dict[str, XLSXFile]] = None
 
     def __init__(self, filename, **kwargs):


### PR DESCRIPTION
Biological data are currently ingested by reading in multiple *.xlsx files. The desired goal is to be able to consolidate this into a single *.xlsx (across multiple sheets).

* Adjust validator to accommodate single biodata file input

* Enable ship user-designations

* Adjust survey data loading functions to appropriately filter biodata upon ingestion

* Pre-commit fixes

* Changes to `pytest` to incorporate updated biodata ingestion functionality