### PR TITLE
Add additional example workflows for hake survey processing

### DIFF
--- a/echopop/nwfsc_feat/FEAT/parameters.py
+++ b/echopop/nwfsc_feat/FEAT/parameters.py
@@ -85,3 +85,1131 @@ def transect_mesh_region_2019(
         transect_upper_bound = [i + 0.4 for i in range(transect_start, transect_end + 1)]
 
     return transect_start, transect_end, transect_lower_bound, transect_upper_bound
+
+
+def transect_mesh_region_2017(
+    region: np.number,
+) -> Tuple[np.number, np.number, List[np.number], List[np.number]]:
+    """
+    Generate region-specific transect boundaries for the 2017 NWFSC survey.
+
+    This function defines the spatial boundaries for three distinct survey regions used in the
+    2017 Northwest Fisheries Science Center (NWFSC) survey. Each region has specific transect
+    numbering schemes and boundary definitions.
+
+    Parameters
+    ----------
+    region : np.number
+        Region identifier (1, 2, or 3):
+        - Region 1: Parallel transects to latitudes from south of SCB to west of Haida Gwaii
+        - Region 2: Transects parallel to longitudes north of Haida Gwaii
+        - Region 3: Parallel transects to latitudes west of Haida Gwaii
+
+    Returns
+    -------
+    Tuple[np.number, np.number, List[np.number], List[np.number]]
+        A tuple containing:
+        - transect_start (np.number): Starting transect number for the region
+        - transect_end (np.number): Ending transect number for the region
+        - transect_lower_bound (List[np.number]): Lower boundary values for each transect
+        - transect_upper_bound (List[np.number]): Upper boundary values for each transect
+
+    Examples
+    --------
+    >>> start, end, lower, upper = transect_mesh_region_2019(1)
+    >>> print(f"Region 1: transects {start} to {end}")
+    Region 1: transects 1 to 119
+    >>> print(f"Lower bounds: {lower[:3]}")  # First 3 values
+    Lower bounds: [1.1, 2.1, 3.1]
+
+    Notes
+    -----
+    The boundary values are encoded with decimal places that indicate spatial positions:
+    - .1 indicates western boundary (for regions 1 and 3)
+    - .4 indicates eastern boundary (for regions 1 and 3)
+    - .6 indicates southern boundary (for region 2)
+    - .9 indicates northern boundary (for region 2)
+    """
+
+    # Initialize variables
+    transect_start = None
+    transect_end = None
+    transect_lower_bound = []  # W/S
+    transect_upper_bound = []  # E/N
+
+    # Region 1: parallel transects to latitudes from south of SCB to west of Haida Gwaii
+    if region == 1:
+        # ---- Southern-most transect
+        transect_start = 1
+        # ---- Northern-most transect
+        transect_end = 119
+        # ---- Western boundary
+        transect_lower_bound = [i + 0.1 for i in range(transect_start, transect_end + 1)]
+        # ---- Eastern boundary
+        transect_upper_bound = [i + 0.4 for i in range(transect_start, transect_end + 1)]
+    # Region 2: transects parallel to longitudes north of Haida Gwaii
+    elif region == 2:
+        # ---- Western-most transect
+        transect_start = 120
+        # ---- Eastern-most transect
+        transect_end = 126
+        # ---- Southern boundary
+        transect_lower_bound = [i + 0.6 for i in range(transect_start, transect_end + 1)]
+        # ---- Northern boundary
+        transect_upper_bound = [i + 0.9 for i in range(transect_start, transect_end + 1)]
+    # Region 3: parallel transects to latitudes west of Haida Gwaii
+    else:
+        # ---- Southern-most transect
+        transect_start = 127
+        # ---- Northern-most transect
+        transect_end = 144
+        # ---- Western boundary
+        transect_lower_bound = [i + 0.1 for i in range(transect_start, transect_end + 1)]
+        # ---- Eastern boundary
+        transect_upper_bound = [i + 0.4 for i in range(transect_start, transect_end + 1)]
+
+    return transect_start, transect_end, transect_lower_bound, transect_upper_bound
+
+
+def transect_mesh_region_2015(
+    region: np.number,
+) -> Tuple[np.number, np.number, List[np.number], List[np.number]]:
+    """
+    Generate region-specific transect boundaries for the 2015 NWFSC survey.
+
+    This function defines the spatial boundaries for three distinct survey regions used in the
+    2015 Northwest Fisheries Science Center (NWFSC) survey. Each region has specific transect
+    numbering schemes and boundary definitions.
+
+    Parameters
+    ----------
+    region : np.number
+        Region identifier (1, 2, or 3):
+        - Region 1: Parallel transects to latitudes from south of SCB to west of Haida Gwaii
+        - Region 2: Transects parallel to longitudes north of Haida Gwaii
+        - Region 3: Parallel transects to latitudes west of Haida Gwaii
+
+    Returns
+    -------
+    Tuple[np.number, np.number, List[np.number], List[np.number]]
+        A tuple containing:
+        - transect_start (np.number): Starting transect number for the region
+        - transect_end (np.number): Ending transect number for the region
+        - transect_lower_bound (List[np.number]): Lower boundary values for each transect
+        - transect_upper_bound (List[np.number]): Upper boundary values for each transect
+
+    Examples
+    --------
+    >>> start, end, lower, upper = transect_mesh_region_2019(1)
+    >>> print(f"Region 1: transects {start} to {end}")
+    Region 1: transects 1 to 119
+    >>> print(f"Lower bounds: {lower[:3]}")  # First 3 values
+    Lower bounds: [1.1, 2.1, 3.1]
+
+    Notes
+    -----
+    The boundary values are encoded with decimal places that indicate spatial positions:
+    - .1 indicates western boundary (for regions 1 and 3)
+    - .4 indicates eastern boundary (for regions 1 and 3)
+    - .6 indicates southern boundary (for region 2)
+    - .9 indicates northern boundary (for region 2)
+    """
+
+    # Initialize variables
+    transect_start = None
+    transect_end = None
+    transect_lower_bound = []  # W/S
+    transect_upper_bound = []  # E/N
+
+    # Region 1: parallel transects to latitudes from south of SCB to west of Haida Gwaii
+    if region == 1:
+        # ---- Southern-most transect
+        transect_start = 1
+        # ---- Northern-most transect
+        transect_end = 90
+        # ---- Western boundary
+        transect_lower_bound = [i + 0.1 for i in range(transect_start, transect_end + 1)]
+        # ---- Eastern boundary
+        transect_upper_bound = [i + 0.4 for i in range(transect_start, transect_end + 1)]
+    # Region 2: transects parallel to longitudes north of Haida Gwaii
+    elif region == 2:
+        # ---- Western-most transect
+        transect_start = 90
+        # ---- Eastern-most transect
+        transect_end = 102
+        # ---- Southern boundary
+        transect_lower_bound = [90.1, 92.6, 102.4]
+        # ---- Northern boundary
+        transect_upper_bound = [90.4, 92.9, 102.1]
+    # Region 3: parallel transects to latitudes west of Haida Gwaii
+    else:
+        # ---- Southern-most transect
+        transect_start = 75
+        # ---- Northern-most transect
+        transect_end = 102
+        # ---- Western boundary
+        transect_lower_bound = [75.1, 102.1, 104.1, 108.1, 110.1, 112.1, 114.1, 116.1]
+        # ---- Eastern boundary
+        transect_upper_bound = [75.4, 102.4, 104.4, 108.4, 110.4, 112.4, 114.4, 116.4]
+
+    return transect_start, transect_end, transect_lower_bound, transect_upper_bound
+
+
+def transect_mesh_region_2013(
+    region: np.number,
+) -> Tuple[np.number, np.number, List[np.number], List[np.number]]:
+    """
+    Generate region-specific transect boundaries for the 2013 NWFSC survey.
+
+    This function defines the spatial boundaries for three distinct survey regions used in the
+    2013 Northwest Fisheries Science Center (NWFSC) survey. Each region has specific transect
+    numbering schemes and boundary definitions.
+
+    Parameters
+    ----------
+    region : np.number
+        Region identifier (1, 2, or 3):
+        - Region 1: Parallel transects to latitudes from south of SCB to west of Haida Gwaii
+        - Region 2: Transects parallel to longitudes north of Haida Gwaii
+        - Region 3: Parallel transects to latitudes west of Haida Gwaii
+
+    Returns
+    -------
+    Tuple[np.number, np.number, List[np.number], List[np.number]]
+        A tuple containing:
+        - transect_start (np.number): Starting transect number for the region
+        - transect_end (np.number): Ending transect number for the region
+        - transect_lower_bound (List[np.number]): Lower boundary values for each transect
+        - transect_upper_bound (List[np.number]): Upper boundary values for each transect
+
+    Examples
+    --------
+    >>> start, end, lower, upper = transect_mesh_region_2019(1)
+    >>> print(f"Region 1: transects {start} to {end}")
+    Region 1: transects 1 to 119
+    >>> print(f"Lower bounds: {lower[:3]}")  # First 3 values
+    Lower bounds: [1.1, 2.1, 3.1]
+
+    Notes
+    -----
+    The boundary values are encoded with decimal places that indicate spatial positions:
+    - .1 indicates western boundary (for regions 1 and 3)
+    - .4 indicates eastern boundary (for regions 1 and 3)
+    - .6 indicates southern boundary (for region 2)
+    - .9 indicates northern boundary (for region 2)
+    """
+
+    # Initialize variables
+    transect_start = None
+    transect_end = None
+    transect_lower_bound = []  # W/S
+    transect_upper_bound = []  # E/N
+
+    # Region 1: parallel transects to latitudes from south of SCB to west of Haida Gwaii
+    if region == 1:
+        # ---- Southern-most transect
+        transect_start = 1
+        # ---- Northern-most transect
+        transect_end = 117
+        # ---- Western boundary
+        transect_lower_bound = [i + 0.1 for i in range(transect_start, transect_end + 1)]
+        # ---- Eastern boundary
+        transect_upper_bound = [i + 0.4 for i in range(transect_start, transect_end + 1)]
+    # Region 2: transects parallel to longitudes north of Haida Gwaii
+    elif region == 2:
+        # ---- Western-most transect
+        transect_start = 117
+        # ---- Eastern-most transect
+        transect_end = 123
+        # ---- Southern boundary
+        transect_lower_bound = [114.4, 114.1, 115.1, 118.6, 119.6, 120.6, 122.6, 124.6]
+        # ---- Northern boundary
+        transect_upper_bound = [114.4, 117.4, 118.9, 119.9, 120.9, 122.9, 124.9]
+    # Region 3: parallel transects to latitudes west of Haida Gwaii
+    else:
+        # ---- Southern-most transect
+        transect_start = 101
+        # ---- Northern-most transect
+        transect_end = 125
+        # ---- Western boundary
+        transect_lower_bound = list(np.array([101, 137, 135, 133, 130, 127, 126, 125]) + 0.1)
+        # ---- Eastern boundary
+        transect_upper_bound = [101.1, 102.1, 103.1, 138.4, 135.4, 133.4, 130.4, 123.6, 123.9]
+
+    return transect_start, transect_end, transect_lower_bound, transect_upper_bound
+
+
+def transect_mesh_region_2012(
+    region: np.number,
+) -> Tuple[np.number, np.number, List[np.number], List[np.number]]:
+    """
+    Generate region-specific transect boundaries for the 2012 NWFSC survey.
+
+    This function defines the spatial boundaries for three distinct survey regions used in the
+    2012 Northwest Fisheries Science Center (NWFSC) survey. Each region has specific transect
+    numbering schemes and boundary definitions.
+
+    Parameters
+    ----------
+    region : np.number
+        Region identifier (1, 2, or 3):
+        - Region 1: Parallel transects to latitudes from south of SCB to west of Haida Gwaii
+        - Region 2: Transects parallel to longitudes north of Haida Gwaii
+        - Region 3: Parallel transects to latitudes west of Haida Gwaii
+
+    Returns
+    -------
+    Tuple[np.number, np.number, List[np.number], List[np.number]]
+        A tuple containing:
+        - transect_start (np.number): Starting transect number for the region
+        - transect_end (np.number): Ending transect number for the region
+        - transect_lower_bound (List[np.number]): Lower boundary values for each transect
+        - transect_upper_bound (List[np.number]): Upper boundary values for each transect
+
+    Examples
+    --------
+    >>> start, end, lower, upper = transect_mesh_region_2019(1)
+    >>> print(f"Region 1: transects {start} to {end}")
+    Region 1: transects 1 to 119
+    >>> print(f"Lower bounds: {lower[:3]}")  # First 3 values
+    Lower bounds: [1.1, 2.1, 3.1]
+
+    Notes
+    -----
+    The boundary values are encoded with decimal places that indicate spatial positions:
+    - .1 indicates western boundary (for regions 1 and 3)
+    - .4 indicates eastern boundary (for regions 1 and 3)
+    - .6 indicates southern boundary (for region 2)
+    - .9 indicates northern boundary (for region 2)
+    """
+
+    # Initialize variables
+    transect_start = None
+    transect_end = None
+    transect_lower_bound = []  # W/S
+    transect_upper_bound = []  # E/N
+
+    # Region 1: parallel transects to latitudes from south of SCB to west of Haida Gwaii
+    if region == 1:
+        # ---- Southern-most transect
+        transect_start = 1
+        # ---- Northern-most transect
+        transect_end = 107
+        # ---- Western boundary
+        transect_lower_bound = [i + 0.1 for i in range(transect_start, transect_end + 1)]
+        # ---- Eastern boundary
+        transect_upper_bound = [i + 0.4 for i in range(transect_start, transect_end + 1)]
+    # Region 2: transects parallel to longitudes north of Haida Gwaii
+    elif region == 2:
+        # ---- Western-most transect
+        transect_start = 107
+        # ---- Eastern-most transect
+        transect_end = 116
+        # ---- Southern boundary
+        transect_lower_bound = [105.4, 105.1, 111.6, 113.6, 115.6, 117.6]
+        # ---- Northern boundary
+        transect_upper_bound = [105.4, 111.9, 113.9, 115.9, 117.9]
+    # Region 3: parallel transects to latitudes west of Haida Gwaii
+    else:
+        # ---- Southern-most transect
+        transect_start = 97
+        # ---- Northern-most transect
+        transect_end = 120.1
+        # ---- Western boundary
+        transect_lower_bound = list(np.array([97, 135, 131, 129, 127, 125, 123, 121, 120]) + 0.1)
+        # ---- Eastern boundary
+        transect_upper_bound = [97.1, 99.1, 133.4, 131.4, 129.4, 128.4, 126.4, 117.6, 117.9, 119.4]
+
+    return transect_start, transect_end, transect_lower_bound, transect_upper_bound
+
+
+def transect_mesh_region_2011(
+    region: np.number,
+) -> Tuple[np.number, np.number, List[np.number], List[np.number]]:
+    """
+    Generate region-specific transect boundaries for the 2011 NWFSC survey.
+
+    This function defines the spatial boundaries for three distinct survey regions used in the
+    2011 Northwest Fisheries Science Center (NWFSC) survey. Each region has specific transect
+    numbering schemes and boundary definitions.
+
+    Parameters
+    ----------
+    region : np.number
+        Region identifier (1, 2, or 3):
+        - Region 1: Parallel transects to latitudes from south of SCB to west of Haida Gwaii
+        - Region 2: Transects parallel to longitudes north of Haida Gwaii
+        - Region 3: Parallel transects to latitudes west of Haida Gwaii
+
+    Returns
+    -------
+    Tuple[np.number, np.number, List[np.number], List[np.number]]
+        A tuple containing:
+        - transect_start (np.number): Starting transect number for the region
+        - transect_end (np.number): Ending transect number for the region
+        - transect_lower_bound (List[np.number]): Lower boundary values for each transect
+        - transect_upper_bound (List[np.number]): Upper boundary values for each transect
+
+    Examples
+    --------
+    >>> start, end, lower, upper = transect_mesh_region_2019(1)
+    >>> print(f"Region 1: transects {start} to {end}")
+    Region 1: transects 1 to 119
+    >>> print(f"Lower bounds: {lower[:3]}")  # First 3 values
+    Lower bounds: [1.1, 2.1, 3.1]
+
+    Notes
+    -----
+    The boundary values are encoded with decimal places that indicate spatial positions:
+    - .1 indicates western boundary (for regions 1 and 3)
+    - .4 indicates eastern boundary (for regions 1 and 3)
+    - .6 indicates southern boundary (for region 2)
+    - .9 indicates northern boundary (for region 2)
+    """
+
+    # Initialize variables
+    transect_start = None
+    transect_end = None
+    transect_lower_bound = []  # W/S
+    transect_upper_bound = []  # E/N
+
+    # Region 1: parallel transects to latitudes from south of SCB to west of Haida Gwaii
+    if region == 1:
+        # ---- Southern-most transect
+        transect_start = 1
+        # ---- Northern-most transect
+        transect_end = 117
+        # ---- Western boundary
+        transect_lower_bound = list(
+            np.concatenate((np.arange(transect_start, 78), np.arange(83, transect_end + 1))) + 0.1
+        )
+        # ---- Eastern boundary
+        transect_upper_bound = [i + 0.4 for i in range(transect_start, transect_end + 1)]
+    # Region 2: transects parallel to longitudes north of Haida Gwaii
+    elif region == 2:
+        # ---- Western-most transect
+        transect_start = 117
+        # ---- Eastern-most transect
+        transect_end = 124
+        # ---- Southern boundary
+        transect_lower_bound = [114.4, 114.1, 117.1, 120.6, 122.6, 124.6]
+        # ---- Northern boundary
+        transect_upper_bound = [114.4, 117.4, 120.9, 122.9, 124.9]
+    # Region 3: parallel transects to latitudes west of Haida Gwaii
+    else:
+        # ---- Southern-most transect
+        transect_start = 106
+        # ---- Northern-most transect
+        transect_end = 128
+        # ---- Western boundary
+        transect_lower_bound = [105.1, 138.1, 136.1, 132.1, 130.1, 128.1]
+        # ---- Eastern boundary
+        transect_upper_bound = [105.1, 144.4, 138.4, 136.4, 134.4, 132.4, 124.6, 122.6, 128.4]
+
+    return transect_start, transect_end, transect_lower_bound, transect_upper_bound
+
+
+def transect_mesh_region_2009(
+    region: np.number,
+) -> Tuple[np.number, np.number, List[np.number], List[np.number]]:
+    """
+    Generate region-specific transect boundaries for the 2009 NWFSC survey.
+
+    This function defines the spatial boundaries for three distinct survey regions used in the
+    2009 Northwest Fisheries Science Center (NWFSC) survey. Each region has specific transect
+    numbering schemes and boundary definitions.
+
+    Parameters
+    ----------
+    region : np.number
+        Region identifier (1, 2, or 3):
+        - Region 1: Parallel transects to latitudes from south of SCB to west of Haida Gwaii
+        - Region 2: Transects parallel to longitudes north of Haida Gwaii
+        - Region 3: Parallel transects to latitudes west of Haida Gwaii
+
+    Returns
+    -------
+    Tuple[np.number, np.number, List[np.number], List[np.number]]
+        A tuple containing:
+        - transect_start (np.number): Starting transect number for the region
+        - transect_end (np.number): Ending transect number for the region
+        - transect_lower_bound (List[np.number]): Lower boundary values for each transect
+        - transect_upper_bound (List[np.number]): Upper boundary values for each transect
+
+    Examples
+    --------
+    >>> start, end, lower, upper = transect_mesh_region_2019(1)
+    >>> print(f"Region 1: transects {start} to {end}")
+    Region 1: transects 1 to 119
+    >>> print(f"Lower bounds: {lower[:3]}")  # First 3 values
+    Lower bounds: [1.1, 2.1, 3.1]
+
+    Notes
+    -----
+    The boundary values are encoded with decimal places that indicate spatial positions:
+    - .1 indicates western boundary (for regions 1 and 3)
+    - .4 indicates eastern boundary (for regions 1 and 3)
+    - .6 indicates southern boundary (for region 2)
+    - .9 indicates northern boundary (for region 2)
+    """
+
+    # Initialize variables
+    transect_start = None
+    transect_end = None
+    transect_lower_bound = []  # W/S
+    transect_upper_bound = []  # E/N
+
+    # Region 1: parallel transects to latitudes from south of SCB to west of Haida Gwaii
+    if region == 1:
+        # ---- Southern-most transect
+        transect_start = 1
+        # ---- Northern-most transect
+        transect_end = 112
+        # ---- Western boundary
+        transect_lower_bound = list(
+            np.concatenate((np.arange(transect_start, 97), np.arange(98, 111))) + 0.1
+        ) + [113.9]
+        # ---- Eastern boundary
+        transect_upper_bound = list(np.arange(transect_start, 105) + 0.4) + [112.9]
+    # Region 2: transects parallel to longitudes north of Haida Gwaii
+    elif region == 2:
+        # ---- Western-most transect
+        transect_start = 111
+        # ---- Eastern-most transect
+        transect_end = 124
+        # ---- Southern boundary
+        transect_lower_bound = [111.9, 109.4, 113.6, 114.6, 115.6, 116.6, 117.6, 127.4, 124.1]
+        # ---- Northern boundary
+        transect_upper_bound = [111.9, 112.6] + list(np.arange(112, 118) + 0.9) + [124.4]
+    # Region 3: parallel transects to latitudes west of Haida Gwaii
+    else:
+        # ---- Southern-most transect
+        transect_start = 96
+        # ---- Northern-most transect
+        transect_end = 124
+        # ---- Western boundary
+        transect_lower_bound = list(np.concatenate(([124], np.arange(127, 135), [139, 98])) + 0.1)
+        # ---- Eastern boundary
+        transect_upper_bound = list(np.concatenate(([124, 117], np.arange(128, 134))) + 0.4) + [
+            96.1
+        ]
+
+    return transect_start, transect_end, transect_lower_bound, transect_upper_bound
+
+
+def transect_mesh_region_2007(
+    region: np.number,
+) -> Tuple[np.number, np.number, List[np.number], List[np.number]]:
+    """
+    Generate region-specific transect boundaries for the 2007 NWFSC survey.
+
+    This function defines the spatial boundaries for three distinct survey regions used in the
+    2007 Northwest Fisheries Science Center (NWFSC) survey. Each region has specific transect
+    numbering schemes and boundary definitions.
+
+    Parameters
+    ----------
+    region : np.number
+        Region identifier (1, 2, or 3):
+        - Region 1: Parallel transects to latitudes from south of SCB to west of Haida Gwaii
+        - Region 2: Transects parallel to longitudes north of Haida Gwaii
+        - Region 3: Parallel transects to latitudes west of Haida Gwaii
+
+    Returns
+    -------
+    Tuple[np.number, np.number, List[np.number], List[np.number]]
+        A tuple containing:
+        - transect_start (np.number): Starting transect number for the region
+        - transect_end (np.number): Ending transect number for the region
+        - transect_lower_bound (List[np.number]): Lower boundary values for each transect
+        - transect_upper_bound (List[np.number]): Upper boundary values for each transect
+
+    Examples
+    --------
+    >>> start, end, lower, upper = transect_mesh_region_2019(1)
+    >>> print(f"Region 1: transects {start} to {end}")
+    Region 1: transects 1 to 119
+    >>> print(f"Lower bounds: {lower[:3]}")  # First 3 values
+    Lower bounds: [1.1, 2.1, 3.1]
+
+    Notes
+    -----
+    The boundary values are encoded with decimal places that indicate spatial positions:
+    - .1 indicates western boundary (for regions 1 and 3)
+    - .4 indicates eastern boundary (for regions 1 and 3)
+    - .6 indicates southern boundary (for region 2)
+    - .9 indicates northern boundary (for region 2)
+    """
+
+    # Initialize variables
+    transect_start = None
+    transect_end = None
+    transect_lower_bound = []  # W/S
+    transect_upper_bound = []  # E/N
+
+    # Region 1: parallel transects to latitudes from south of SCB to west of Haida Gwaii
+    if region == 1:
+        # ---- Southern-most transect
+        transect_start = 1
+        # ---- Northern-most transect
+        transect_end = 111
+        # ---- Western boundary
+        transect_lower_bound = [i + 0.1 for i in range(transect_start, transect_end + 1)]
+        # ---- Eastern boundary
+        transect_upper_bound = [i + 0.4 for i in range(transect_start, transect_end + 1)]
+    # Region 2: transects parallel to longitudes north of Haida Gwaii
+    elif region == 2:
+        # ---- Western-most transect
+        transect_start = 111
+        # ---- Eastern-most transect
+        transect_end = 117
+        # ---- Southern boundary
+        transect_lower_bound = [111.1] + [i + 0.6 for i in range(transect_start, transect_end + 1)]
+        # ---- Northern boundary
+        transect_upper_bound = [111.4] + [i + 0.9 for i in range(transect_start, transect_end + 1)]
+    # Region 3: parallel transects to latitudes west of Haida Gwaii
+    else:
+        # ---- Southern-most transect
+        transect_start = 97
+        # ---- Northern-most transect
+        transect_end = 119
+        # ---- Western boundary
+        transect_lower_bound = list(
+            np.concatenate(
+                (np.arange(119, 116, -1), np.arange(126, 136), np.arange(137, 142), [97])
+            )
+            + 0.1
+        )
+        # ---- Eastern boundary
+        transect_upper_bound = (
+            [119.4, 118.4, 116.9, 116.6]
+            + list(np.concatenate((np.arange(128, 136), np.arange(137, 142))) + 0.4)
+            + [98.1]
+        )
+
+    return transect_start, transect_end, transect_lower_bound, transect_upper_bound
+
+
+def transect_mesh_region_2005(
+    region: np.number,
+) -> Tuple[np.number, np.number, List[np.number], List[np.number]]:
+    """
+    Generate region-specific transect boundaries for the 2005 NWFSC survey.
+
+    This function defines the spatial boundaries for three distinct survey regions used in the
+    2005 Northwest Fisheries Science Center (NWFSC) survey. Each region has specific transect
+    numbering schemes and boundary definitions.
+
+    Parameters
+    ----------
+    region : np.number
+        Region identifier (1, 2, or 3):
+        - Region 1: Parallel transects to latitudes from south of SCB to west of Haida Gwaii
+        - Region 2: Transects parallel to longitudes north of Haida Gwaii
+        - Region 3: Parallel transects to latitudes west of Haida Gwaii
+
+    Returns
+    -------
+    Tuple[np.number, np.number, List[np.number], List[np.number]]
+        A tuple containing:
+        - transect_start (np.number): Starting transect number for the region
+        - transect_end (np.number): Ending transect number for the region
+        - transect_lower_bound (List[np.number]): Lower boundary values for each transect
+        - transect_upper_bound (List[np.number]): Upper boundary values for each transect
+
+    Examples
+    --------
+    >>> start, end, lower, upper = transect_mesh_region_2019(1)
+    >>> print(f"Region 1: transects {start} to {end}")
+    Region 1: transects 1 to 119
+    >>> print(f"Lower bounds: {lower[:3]}")  # First 3 values
+    Lower bounds: [1.1, 2.1, 3.1]
+
+    Notes
+    -----
+    The boundary values are encoded with decimal places that indicate spatial positions:
+    - .1 indicates western boundary (for regions 1 and 3)
+    - .4 indicates eastern boundary (for regions 1 and 3)
+    - .6 indicates southern boundary (for region 2)
+    - .9 indicates northern boundary (for region 2)
+    """
+
+    # Initialize variables
+    transect_start = None
+    transect_end = None
+    transect_lower_bound = []  # W/S
+    transect_upper_bound = []  # E/N
+
+    # Region 1: parallel transects to latitudes from south of SCB to west of Haida Gwaii
+    if region == 1:
+        # ---- Southern-most transect
+        transect_start = 1
+        # ---- Northern-most transect
+        transect_end = 108
+        # ---- Western boundary
+        transect_lower_bound = list(
+            np.concatenate((np.arange(transect_start, 107), [transect_end])) + 0.1
+        )
+        # ---- Eastern boundary
+        transect_upper_bound = list(
+            np.concatenate(
+                (np.arange(transect_start, 94), [107], np.arange(97, 107), [transect_end])
+            )
+            + 0.4
+        )
+    # Region 2: transects parallel to longitudes north of Haida Gwaii
+    elif region == 2:
+        # ---- Western-most transect
+        transect_start = 108
+        # ---- Eastern-most transect
+        transect_end = 111
+        # ---- Southern boundary
+        transect_lower_bound = [108.1] + list(np.array([109, 111]) + 0.6)
+        # ---- Northern boundary
+        transect_upper_bound = [108.4] + list(np.array([109, 111]) + 0.9)
+    # Region 3: parallel transects to latitudes west of Haida Gwaii
+    else:
+        # ---- Southern-most transect
+        transect_start = 97
+        # ---- Northern-most transect
+        transect_end = 113
+        # ---- Western boundary
+        transect_lower_bound = list(np.concatenate((np.arange(113, 124, 2), [97])) + 0.1)
+        # ---- Eastern boundary
+        transect_upper_bound = [113.4, 111.9, 111.6] + list(np.arange(115, 124, 2) + 0.4) + [97.4]
+
+    return transect_start, transect_end, transect_lower_bound, transect_upper_bound
+
+
+def transect_mesh_region_2003(
+    region: np.number,
+) -> Tuple[np.number, np.number, List[np.number], List[np.number]]:
+    """
+    Generate region-specific transect boundaries for the 2003 NWFSC survey.
+
+    This function defines the spatial boundaries for three distinct survey regions used in the
+    2003 Northwest Fisheries Science Center (NWFSC) survey. Each region has specific transect
+    numbering schemes and boundary definitions.
+
+    Parameters
+    ----------
+    region : np.number
+        Region identifier (1, 2, or 3):
+        - Region 1: Parallel transects to latitudes from south of SCB to west of Haida Gwaii
+        - Region 2: Transects parallel to longitudes north of Haida Gwaii
+        - Region 3: Parallel transects to latitudes west of Haida Gwaii
+
+    Returns
+    -------
+    Tuple[np.number, np.number, List[np.number], List[np.number]]
+        A tuple containing:
+        - transect_start (np.number): Starting transect number for the region
+        - transect_end (np.number): Ending transect number for the region
+        - transect_lower_bound (List[np.number]): Lower boundary values for each transect
+        - transect_upper_bound (List[np.number]): Upper boundary values for each transect
+
+    Examples
+    --------
+    >>> start, end, lower, upper = transect_mesh_region_2019(1)
+    >>> print(f"Region 1: transects {start} to {end}")
+    Region 1: transects 1 to 119
+    >>> print(f"Lower bounds: {lower[:3]}")  # First 3 values
+    Lower bounds: [1.1, 2.1, 3.1]
+
+    Notes
+    -----
+    The boundary values are encoded with decimal places that indicate spatial positions:
+    - .1 indicates western boundary (for regions 1 and 3)
+    - .4 indicates eastern boundary (for regions 1 and 3)
+    - .6 indicates southern boundary (for region 2)
+    - .9 indicates northern boundary (for region 2)
+    """
+
+    # Initialize variables
+    transect_start = None
+    transect_end = None
+    transect_lower_bound = []  # W/S
+    transect_upper_bound = []  # E/N
+
+    # Region 1: parallel transects to latitudes from south of SCB to west of Haida Gwaii
+    if region == 1:
+        # ---- Southern-most transect
+        transect_start = 3
+        # ---- Northern-most transect
+        transect_end = 105
+        # ---- Western boundary
+        transect_lower_bound = list(
+            np.concatenate((np.arange(transect_start, 95), np.arange(117, 120), np.arange(98, 106)))
+            + 0.1
+        )
+        # ---- Eastern boundary
+        transect_upper_bound = list(
+            np.concatenate(
+                (
+                    np.arange(transect_start, 97),
+                    [117],
+                    np.arange(98, 106),
+                )
+            )
+            + 0.4
+        )
+    # Region 2: transects parallel to longitudes north of Haida Gwaii
+    elif region == 2:
+        # ---- Western-most transect
+        transect_start = 105
+        # ---- Eastern-most transect
+        transect_end = 110
+        # ---- Southern boundary
+        transect_lower_bound = [105.1] + list(np.arange(106, 109) + 0.6) + [110.4]
+        # ---- Northern boundary
+        transect_upper_bound = [105.4] + list(np.arange(106, 109) + 0.9) + [109.4]
+    # Region 3: parallel transects to latitudes west of Haida Gwaii
+    else:
+        # ---- Southern-most transect
+        transect_start = 117
+        # ---- Northern-most transect
+        transect_end = 109
+        # ---- Western boundary
+        transect_lower_bound = list(np.arange(109, 118) + 0.1)
+        # ---- Eastern boundary
+        transect_upper_bound = list(np.arange(109, 117) + 0.4) + [98.1, 117.4]
+
+    return transect_start, transect_end, transect_lower_bound, transect_upper_bound
+
+
+def transect_mesh_region_2001(
+    region: np.number,
+) -> Tuple[np.number, np.number, List[np.number], List[np.number]]:
+    """
+    Generate region-specific transect boundaries for the 2001 NWFSC survey.
+
+    This function defines the spatial boundaries for three distinct survey regions used in the
+    2001 Northwest Fisheries Science Center (NWFSC) survey. Each region has specific transect
+    numbering schemes and boundary definitions.
+
+    Parameters
+    ----------
+    region : np.number
+        Region identifier (1, 2, or 3):
+        - Region 1: Parallel transects to latitudes from south of SCB to west of Haida Gwaii
+        - Region 2: Transects parallel to longitudes north of Haida Gwaii
+        - Region 3: Parallel transects to latitudes west of Haida Gwaii
+
+    Returns
+    -------
+    Tuple[np.number, np.number, List[np.number], List[np.number]]
+        A tuple containing:
+        - transect_start (np.number): Starting transect number for the region
+        - transect_end (np.number): Ending transect number for the region
+        - transect_lower_bound (List[np.number]): Lower boundary values for each transect
+        - transect_upper_bound (List[np.number]): Upper boundary values for each transect
+
+    Examples
+    --------
+    >>> start, end, lower, upper = transect_mesh_region_2019(1)
+    >>> print(f"Region 1: transects {start} to {end}")
+    Region 1: transects 1 to 119
+    >>> print(f"Lower bounds: {lower[:3]}")  # First 3 values
+    Lower bounds: [1.1, 2.1, 3.1]
+
+    Notes
+    -----
+    The boundary values are encoded with decimal places that indicate spatial positions:
+    - .1 indicates western boundary (for regions 1 and 3)
+    - .4 indicates eastern boundary (for regions 1 and 3)
+    - .6 indicates southern boundary (for region 2)
+    - .9 indicates northern boundary (for region 2)
+    """
+
+    # Initialize variables
+    transect_start = None
+    transect_end = None
+    transect_lower_bound = []  # W/S
+    transect_upper_bound = []  # E/N
+
+    # Region 1: parallel transects to latitudes from south of SCB to west of Haida Gwaii
+    if region == 1:
+        # ---- Southern-most transect
+        transect_start = 1
+        # ---- Northern-most transect
+        transect_end = 139
+        # ---- Western boundary
+        transect_lower_bound = list(
+            np.concatenate(
+                (np.arange(transect_start, 86), np.arange(151, 146, -1), [144, 141, 140, 139])
+            )
+            + 0.1
+        )
+        # ---- Eastern boundary
+        transect_upper_bound = list(
+            np.concatenate(
+                (
+                    np.arange(transect_start, 86),
+                    np.arange(151, 146, -1),
+                    [144, 141, 140, 139],
+                )
+            )
+            + 0.4
+        )
+    # Region 2: transects parallel to longitudes north of Haida Gwaii
+    elif region == 2:
+        # ---- Western-most transect
+        transect_start = 139
+        # ---- Eastern-most transect
+        transect_end = 134
+        # ---- Southern boundary
+        transect_lower_bound = [139.1] + list(np.arange(138, 135, -1) + 0.6) + [134.4]
+        # ---- Northern boundary
+        transect_upper_bound = [139.4] + list(np.arange(138, 135, -1) + 0.9) + [135.4]
+    # Region 3: parallel transects to latitudes west of Haida Gwaii
+    else:
+        # ---- Southern-most transect
+        transect_start = 83
+        # ---- Northern-most transect
+        transect_end = 135
+        # ---- Western boundary
+        transect_lower_bound = list(
+            np.concatenate(
+                (
+                    np.arange(135, 127, -1),
+                    [147],
+                    np.arange(126, 122, -1),
+                    np.arange(121, 118, -1),
+                )
+            )
+            + 0.1
+        )
+        # ---- Eastern boundary
+        transect_upper_bound = list(
+            np.concatenate(
+                (np.arange(135, 127, -1), np.arange(126, 122, -1), np.arange(121, 118, -1), [83])
+            )
+            + 0.4
+        )
+
+    return transect_start, transect_end, transect_lower_bound, transect_upper_bound
+
+
+def transect_mesh_region_1998(
+    region: np.number,
+) -> Tuple[np.number, np.number, List[np.number], List[np.number]]:
+    """
+    Generate region-specific transect boundaries for the 1998 NWFSC survey.
+
+    This function defines the spatial boundaries for three distinct survey regions used in the
+    1998 Northwest Fisheries Science Center (NWFSC) survey. Each region has specific transect
+    numbering schemes and boundary definitions.
+
+    Parameters
+    ----------
+    region : np.number
+        Region identifier (1, 2, or 3):
+        - Region 1: Parallel transects to latitudes from south of SCB to west of Haida Gwaii
+        - Region 2: Transects parallel to longitudes north of Haida Gwaii
+        - Region 3: Parallel transects to latitudes west of Haida Gwaii
+
+    Returns
+    -------
+    Tuple[np.number, np.number, List[np.number], List[np.number]]
+        A tuple containing:
+        - transect_start (np.number): Starting transect number for the region
+        - transect_end (np.number): Ending transect number for the region
+        - transect_lower_bound (List[np.number]): Lower boundary values for each transect
+        - transect_upper_bound (List[np.number]): Upper boundary values for each transect
+
+    Examples
+    --------
+    >>> start, end, lower, upper = transect_mesh_region_2019(1)
+    >>> print(f"Region 1: transects {start} to {end}")
+    Region 1: transects 1 to 119
+    >>> print(f"Lower bounds: {lower[:3]}")  # First 3 values
+    Lower bounds: [1.1, 2.1, 3.1]
+
+    Notes
+    -----
+    The boundary values are encoded with decimal places that indicate spatial positions:
+    - .1 indicates western boundary (for regions 1 and 3)
+    - .4 indicates eastern boundary (for regions 1 and 3)
+    - .6 indicates southern boundary (for region 2)
+    - .9 indicates northern boundary (for region 2)
+    """
+
+    # Initialize variables
+    transect_start = None
+    transect_end = None
+    transect_lower_bound = []  # W/S
+    transect_upper_bound = []  # E/N
+
+    # Region 1: parallel transects to latitudes from south of SCB to west of Haida Gwaii
+    if region == 1:
+        # ---- Southern-most transect
+        transect_start = 1
+        # ---- Northern-most transect
+        transect_end = 222
+        # ---- Western boundary
+        transect_lower_bound = (
+            list(
+                np.concatenate((np.arange(transect_start, 71), np.arange(81, 104), [249, 252]))
+                + 0.1
+            )
+            + [253.6, 253.9]
+            + list(np.array([254, 248, 245, 239, 238, 236, 233, 231, 227]) + 0.1)
+            + [226.6, 211.6]
+        )
+        # ---- Eastern boundary
+        transect_upper_bound = list(
+            np.concatenate(
+                (
+                    np.arange(transect_start, 61),
+                    np.arange(70, 81),
+                    [99, 265, 262, 260, 271, 274, 255, 246, 238, 236, 233, 231, 229],
+                )
+            )
+            + 0.4
+        ) + [226.9, 223.9, 222.4, 211.9]
+    # Region 2: transects parallel to longitudes north of Haida Gwaii
+    elif region == 2:
+        # ---- Western-most transect
+        transect_start = 224
+        # ---- Eastern-most transect
+        transect_end = 319
+        # ---- Southern boundary
+        transect_lower_bound = list(np.array([226, 211, 209, 207, 205, 202]) + 0.6) + [320.4]
+        # ---- Northern boundary
+        transect_upper_bound = [224.6] + list(np.array([211, 217, 215, 213]) + 0.9) + [212.1, 325.4]
+    # Region 3: parallel transects to latitudes west of Haida Gwaii
+    else:
+        # ---- Southern-most transect
+        transect_start = 103
+        # ---- Northern-most transect
+        transect_end = 368
+        # ---- Western boundary
+        transect_lower_bound = (
+            [368.6, 367.4]
+            + list(np.array([365.6, 363, 360, 358, 356, 353]) + 0.6)
+            + list(np.array([351, 347]) + 0.1)
+            + [343.6]
+            + list(np.array([340, 338, 331]) + 0.1)
+            + [330.6, 328.6]
+            + list(
+                np.concatenate(
+                    ([325, 322, 320, 318, 316], np.arange(313, 301, -2), [300, 298, 294])
+                )
+                + 0.1
+            )
+            + [293.6]
+            + list(np.array([286, 284, 282, 103]) + 0.1)
+        )
+        # ---- Eastern boundary
+        transect_upper_bound = (
+            [368.9, 366.4, 364.9]
+            + list(np.array([360, 359, 357, 354, 352, 347, 345, 344, 342, 340, 336, 334]) + 0.4)
+            + [330.9]
+            + list(np.array([329, 327, 324]) + 0.4)
+            + [212.1, 322.4, 321.6]
+            + list(np.concatenate(([318, 316], np.arange(313, 306, -2), [304])) + 0.4)
+            + [302.9, 300.4, 298.4, 297.9]
+            + list(np.concatenate(([295], np.arange(292, 281, -2))) + 0.4)
+        )
+
+    return transect_start, transect_end, transect_lower_bound, transect_upper_bound
+
+
+def transect_mesh_region_1995(
+    region: np.number,
+) -> Tuple[np.number, np.number, List[np.number], List[np.number]]:
+    """
+    Generate region-specific transect boundaries for the 1995 NWFSC survey.
+
+    This function defines the spatial boundaries for three distinct survey regions used in the
+    1995 Northwest Fisheries Science Center (NWFSC) survey. Each region has specific transect
+    numbering schemes and boundary definitions.
+
+    Parameters
+    ----------
+    region : np.number
+        Region identifier (1, 2, or 3):
+        - Region 1: Parallel transects to latitudes from south of SCB to west of Haida Gwaii
+        - Region 2: Transects parallel to longitudes north of Haida Gwaii
+        - Region 3: Parallel transects to latitudes west of Haida Gwaii
+
+    Returns
+    -------
+    Tuple[np.number, np.number, List[np.number], List[np.number]]
+        A tuple containing:
+        - transect_start (np.number): Starting transect number for the region
+        - transect_end (np.number): Ending transect number for the region
+        - transect_lower_bound (List[np.number]): Lower boundary values for each transect
+        - transect_upper_bound (List[np.number]): Upper boundary values for each transect
+
+    Examples
+    --------
+    >>> start, end, lower, upper = transect_mesh_region_2019(1)
+    >>> print(f"Region 1: transects {start} to {end}")
+    Region 1: transects 1 to 119
+    >>> print(f"Lower bounds: {lower[:3]}")  # First 3 values
+    Lower bounds: [1.1, 2.1, 3.1]
+
+    Notes
+    -----
+    The boundary values are encoded with decimal places that indicate spatial positions:
+    - .1 indicates western boundary (for regions 1 and 3)
+    - .4 indicates eastern boundary (for regions 1 and 3)
+    - .6 indicates southern boundary (for region 2)
+    - .9 indicates northern boundary (for region 2)
+    """
+
+    # Initialize variables
+    transect_start = None
+    transect_end = None
+    transect_lower_bound = []  # W/S
+    transect_upper_bound = []  # E/N
+
+    # Region 1: parallel transects to latitudes from south of SCB to west of Haida Gwaii
+    if region == 1:
+        # ---- Southern-most transect
+        transect_start = 1
+        # ---- Northern-most transect
+        transect_end = 152
+        # ---- Western boundary
+        transect_lower_bound = (
+            [transect_start, 2]
+            + list(np.arange(4, 79))
+            + list(np.arange(80, 5, -2))
+            + list(np.arange(89, 100))
+            + list(np.arange(101, 106))
+            + [120, 121]
+            + list(np.arange(124, 128))
+            + list(np.arange(129, 134, 2))
+        )
+        transect_lower_bound = [x + 0.1 for x in transect_lower_bound]
+        # ---- Eastern boundary
+        transect_upper_bound = (
+            [transect_start, 2]
+            + list(np.arange(4, 89))
+            + list(np.arange(91, 106))
+            + [152, 149, 145, 143, 142, 140, 135, 134, 133]
+        )
+        transect_upper_bound = [x + 0.4 for x in transect_upper_bound]
+    # Region 2: transects parallel to longitudes north of Haida Gwaii
+    elif region == 2:
+        # ---- Western-most transect
+        transect_start = 116
+        # ---- Eastern-most transect
+        transect_end = 119
+        # ---- Southern boundary
+        transect_lower_bound = [118.6, 117.6, 119.6, 116.6]
+        # ---- Northern boundary
+        transect_upper_bound = [118.9, 117.9, 119.9, 116.9]
+    # Region 3: parallel transects to latitudes west of Haida Gwaii
+    else:
+        # ---- Southern-most transect
+        transect_start = 106
+        # ---- Northern-most transect
+        transect_end = 128
+        # ---- Western boundary
+        transect_lower_bound = [116.6, 119.6] + [x + 0.1 for x in range(115, 105, -1)] + [126.1]
+        # ---- Eastern boundary
+        transect_upper_bound = [119.6] + [x + 0.4 for x in range(115, 105, -1)] + [128.1]
+
+    return transect_start, transect_end, transect_lower_bound, transect_upper_bound

--- a/echopop/nwfsc_feat/apportion.py
+++ b/echopop/nwfsc_feat/apportion.py
@@ -61,7 +61,7 @@ def remove_group_from_estimates(
     if "nasc" in group_proportions:
         transect_data["nasc"] = transect_data["nasc"] * (
             1 - group_proportions["nasc"].reindex(transect_data.index)
-        )
+        ).fillna(0.0)
     # ---- Drop column to avoid partial evaluation
     else:
         transect_data.drop(columns=["nasc"], inplace=True)
@@ -73,14 +73,14 @@ def remove_group_from_estimates(
         # ---- Map the appropriate columns for abundance
         abundance_names = transect_data.filter(like="abundance").columns
         # ---- Adjust abundances
-        transect_data[abundance_names] = transect_data[abundance_names].mul(
-            abundance_proportions, axis=0
+        transect_data[abundance_names] = (
+            transect_data[abundance_names].mul(abundance_proportions, axis=0).fillna(0.0)
         )
         # ---- Map the appropriate columns for number density
         number_density_names = transect_data.filter(like="number_density").columns
         # ---- Adjust number densities
-        transect_data[number_density_names] = transect_data[number_density_names].mul(
-            abundance_proportions, axis=0
+        transect_data[number_density_names] = (
+            transect_data[number_density_names].mul(abundance_proportions, axis=0).fillna(0.0)
         )
     # ---- Drop columns to avoid partial evaluation
     else:
@@ -96,7 +96,9 @@ def remove_group_from_estimates(
         # ---- Map the appropriate columns for biomass and biomass density
         biomass_names = transect_data.filter(like="biomass").columns
         # ---- Adjust biomass
-        transect_data[biomass_names] = (biomass_proportions * transect_data[biomass_names].T).T
+        transect_data[biomass_names] = (
+            (biomass_proportions * transect_data[biomass_names].T).T
+        ).fillna(0.0)
     # ---- Drop columns to avoid partial evaluation
     else:
         # ---- Gather columns to drop

--- a/echopop/nwfsc_feat/biology.py
+++ b/echopop/nwfsc_feat/biology.py
@@ -325,13 +325,13 @@ def matrix_multiply_grouped_table(
     column_map = target_groups_idx.columns.map(lambda c: f"{output_variable}_{c}")
 
     # Add the output variables
-    dataset[column_map] = table_matrix.values
+    dataset[column_map] = table_matrix.fillna(0.0).values
 
     # Calculate the remainder comprising the ungrouped values
-    remainder = dataset[variable] - dataset[variable_overlap].sum(axis=1)
+    remainder = dataset[variable] - dataset[variable_overlap].fillna(0.0).sum(axis=1)
 
     # Calculate the output variable for the ungrouped/excluded values
-    remainder_matrix = remainder * table_ridx["all"]
+    remainder_matrix = remainder * table_ridx["all"].fillna(0.0)
 
     # Compute the overall output variable
     dataset[output_variable] = dataset[column_map].sum(axis=1) + remainder_matrix

--- a/echopop/nwfsc_feat/utils.py
+++ b/echopop/nwfsc_feat/utils.py
@@ -171,7 +171,7 @@ def _filter_rows(
     df: Union[pd.Series, pd.DataFrame],
     filter_dict: Dict[str, Any],
     include: bool,
-    replace_value: Union[str, None] = None,
+    replace_value: Union[np.number, str, None] = None,
 ) -> pd.DataFrame:
     """Helper function to filter DataFrame rows."""
 

--- a/echopop/workflow/feat_hake_age1_excluded.py
+++ b/echopop/workflow/feat_hake_age1_excluded.py
@@ -1,0 +1,1204 @@
+####################################################################################################
+# FEAT hake survey: age-1 fish excluded
+# -------------------------------------
+from pathlib import Path
+####################################################################################################
+# PARAMETER ENTRY
+# ---------------
+# ** ENTER FILE INFORMATION FOR ALL INGESTED DATASETS.
+# ** ADDITIONAL PARAMETERIZATIONS THROUGHOUT THE SCRIPT SHOULD BE EDITED BASED ON SPECIFIC NEEDS. 
+# ** MAKE SURE TO EDIT WITH CARE.
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# PRINT CONSOLE LOGGING MESSAGES
+# ---- When set to `True`, logging information will be printed in the terminal/console as the 
+# ---- script progresses
+VERBOSE = True
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# DATA ROOT DIRECTORY
+DATA_ROOT = Path("C:/Users/Brandyn Lucca/Documents/Data/echopop_2019")
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# ALREADY PROCESSED NASC FILE ? 
+# ---- When False, the raw NASC exports will be processed. When True, the pre-formatted NASC 
+# ---- spreadsheet will be read in. This also requires defining `NASC_EXPORTS_SHEET`
+NASC_PREPROCESSED = False
+# NASC EXPORTS FILE(S)
+NASC_EXPORTS_FILES = DATA_ROOT / "raw_nasc/"
+# NASC EXPORTS SHEET
+NASC_EXPORTS_SHEET = "Sheet1"
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# BIODATA FILE
+BIODATA_FILE = DATA_ROOT / "Biological/1995-2023_biodata_redo.xlsx"
+# BIODATA SHEETS
+# ---- Assign the sheetnames to 'catch', 'length', 'specimen'
+BIODATA_SHEETS_MAP = {
+    "catch": "biodata_catch",
+    "length": "biodata_length",
+    "specimen": "biodata_specimen",
+}
+# BIODATA PROCESSING: MASTER SPREADSHEET PARSING
+# ---- This is used to parse the biodata master spreadsheet, which is required for aligning the 
+# ---- biodata with ancillary files such as stratification and transect-haul mappings. This should 
+# ---- define the "ships" based on their IDs with the associated survey IDs. If an offset should be 
+# ---- added to the haul numbers, that must also be defined here. The target species should also be 
+# ---- defined here. 
+BIODATA_MAPPING = {
+    "ships": {
+        160: {
+            "survey": 202106
+        },
+        584: {
+            "survey": 202113,
+            "haul_offset": 200
+        }
+    },
+    "species_code": [22500]
+}
+# BIODATA PROCESSING: AGE-1 DOMINATED HAULS
+# ---- This is a list of age-1 dominated haul numbers that should be designated for removal. If no 
+# ---- hauls should be removed, then set `AGE1_DOMINATED_HAULS` to `[]`
+AGE1_DOMINATED_HAULS = []
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# HAUL STRATIFICATION FILE
+HAUL_STRATA_FILE = DATA_ROOT / "Stratification/US_CAN strata 2019_final.xlsx"
+# HAUL STRATIFICATION SHEET MAP
+# ---- Valid keys are limited to "ks" and "inpfc"
+HAUL_STRATA_SHEETS_MAP = {
+    "inpfc": "INPFC",
+    "ks": "Base KS",
+}
+# GEOGRAPHIC STRATIFICATION FILE
+GEOSTRATA_FILE = DATA_ROOT / "Stratification/Stratification_geographic_Lat_2019_final.xlsx"
+# GEOGRAPHIC STRATIFICATION SHEET MAP
+# ---- Valid keys are limited to "ks" and "inpfc"
+GEOSTRATA_SHEETS_MAP = {
+    "inpfc": "INPFC",
+    "ks": "stratification1",
+}
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# KRIGING MESH FILE 
+KRIGING_MESH_FILE = (
+    DATA_ROOT / "Kriging_files/Kriging_grid_files/krig_grid2_5nm_cut_centroids_2013.xlsx"
+)
+# KRIGING MESH SHEET
+KRIGING_MESH_SHEET = "krigedgrid2_5nm_forChu"
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# KRIGING AND VARIOGRAM PARAMETERS FILE
+KRIGING_VARIOGRAM_PARAMETERS_FILE = (
+    DATA_ROOT / "Kriging_files/default_vario_krig_settings_2019_US_CAN.xlsx"
+)
+# KRIGING AND VARIOGRAM PARAMETERS SHEET
+KRIGING_VARIGORAM_PARAMETERS_SHEET = "Sheet1"
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# 200m ISOBATH FILE
+ISOBATH_FILE = (
+    DATA_ROOT / "Kriging_files/Kriging_grid_files/transformation_isobath_coordinates.xlsx"
+)
+# 200m ISOBATH SHEET
+ISOBATH_SHEET = "Smoothing_EasyKrig"
+####################################################################################################
+####################################################################################################
+# !!! START OF PROCESSING SCRIPT !!
+# !!! EDIT CODE BELOW WITH CARE !!
+####################################################################################################
+####################################################################################################
+import logging
+import numpy as np
+import pandas as pd
+from lmfit import Parameters
+from echopop import inversion
+from echopop.nwfsc_feat import (
+    apportion,
+    biology, 
+    FEAT,
+    ingest_nasc, 
+    get_proportions, 
+    kriging,
+    load_data, 
+    spatial,
+    stratified,
+    transect, 
+    utils,
+    variogram
+)
+####################################################################################################
+# FORMAT LOGGER
+for handler in logging.root.handlers[:]:
+    logging.root.removeHandler(handler)
+    
+logging.basicConfig(
+    level=logging.INFO if VERBOSE else logging.WARNING,
+    format="%(message)s")
+# ==================================================================================================
+# DATA INGESTION 
+# ==================================================================================================
+# INGEST NASC DATA 
+if NASC_PREPROCESSED:
+    logging.info(f"Reading pre-generated NASC export file: '{NASC_EXPORTS_FILES.as_posix()}'.")
+
+    # DEFINE COLUMN MAPPING
+    FEAT_TO_ECHOPOP_COLUMNS = {
+        "transect": "transect_num",
+        "region id": "region_id",
+        "vessel_log_start": "distance_s",
+        "vessel_log_end": "distance_e",
+        "spacing": "transect_spacing",
+        "layer mean depth": "layer_mean_depth",
+        "layer height": "layer_height",
+        "bottom depth": "bottom_depth",
+        "assigned haul": "haul_num",
+    }
+
+    # Read file
+    df_nasc = ingest_nasc.read_nasc_file(
+        filename=NASC_EXPORTS_FILES,
+        sheetname=NASC_EXPORTS_SHEET,
+        column_name_map=FEAT_TO_ECHOPOP_COLUMNS
+    )
+else:
+    logging.info(
+        f"Beginning NASC export ingestion for files in: '{NASC_EXPORTS_FILES.as_posix()}'."
+    )
+
+    # MERGE EXPORTS
+    logging.info(
+        "---- Merging NASC exports...\n"
+        "     Filename transect pattern: 'T(\\d+)'\n"
+        "     Default transect spacing: 10.0 nmi\n"
+        "     Default latitude threshold: 60.0 deg."
+    )    
+    df_intervals, df_exports = ingest_nasc.merge_echoview_nasc(
+        nasc_path = NASC_EXPORTS_FILES,
+        filename_transect_pattern = r"T(\d+)",
+        default_transect_spacing = 10.0,
+        default_latitude_threshold = 60.0,
+    )
+
+    # EXPORT REGION NAME MAPPING
+    REGION_NAME_EXPR_DICT = {
+        "REGION_CLASS": {
+            "Age-1 Hake": "^(?:h1a(?![a-z]|m))",
+            "Age-1 Hake Mix": "^(?:h1am(?![a-z]|1a))",
+            "Hake": "^(?:h(?![a-z]|1a)|hake(?![_]))",
+            "Hake Mix": "^(?:hm(?![a-z]|1a)|hake_mix(?![_]))",
+        },
+        "HAUL_NUM": {
+            "[0-9]+",
+        },
+        "COUNTRY": {
+            "CAN": "^[cC]",
+            "US": "^[uU]",
+        },
+    }    
+    
+    # PROCESS REGION NAMES 
+    logging.info(
+        "---- Processing export region names\n"
+        "     Applying CAN haul number offset: 200"
+    )
+    df_exports_with_regions = ingest_nasc.process_region_names(
+        df=df_exports,
+        region_name_expr_dict=REGION_NAME_EXPR_DICT,
+        can_haul_offset=200,
+    )
+
+    # GENERATE TRANSECT-REGION-HAUL KEY
+    logging.info(
+        "---- Generating transect-region-haul key mapping\n"
+        "     Searching for the export regions: 'Age-1 Hake', 'Age-1 Hake Mix', 'Hake', 'Hake Mix'"
+    )
+    df_transect_region_haul_key = ingest_nasc.generate_transect_region_haul_key(
+        df=df_exports_with_regions,
+        filter_list=["Age-1 Hake", "Age-1 Hake Mix", "Hake", "Hake Mix"]
+    )
+    
+    # AGE-1 DOMINATED HAUL REMOVAL
+    logging.info(
+        f"The following age-1 dominated haul numbers have been designated for removal from "
+        f"transect-region-haul key mapping:\n"
+        f"{', '.join(map(str, AGE1_DOMINATED_HAULS))}."
+    )
+    df_transect_region_haul_key = utils.apply_filters(
+        df_transect_region_haul_key, exclude_filter={"haul_num": AGE1_DOMINATED_HAULS}
+    )
+
+    # CONSOLIDATE THE EXPORTS WITH TRANSECT-REGION-HAUL MAPPINGS
+    logging.info(
+        "---- Finalizing NASC export ingestion\n"
+        "     Searching for the export regions: 'Age-1 Hake', 'Age-1 Hake Mix', 'Hake', "
+        "'Hake Mix'\n"
+        "     Imputing overlapping region IDs within each interval: True"
+    )
+    df_nasc = ingest_nasc.consolidate_echvoiew_nasc(
+        df_merged=df_exports_with_regions,
+        interval_df=df_intervals,
+        region_class_names=["Age-1 Hake", "Age-1", "Age-1 Hake Mix", "Hake", "Hake Mix"],
+        impute_region_ids=True,
+        transect_region_haul_key_df=df_transect_region_haul_key
+    )
+logging.info(
+    "NASC ingestion complete\n"
+    "'df_nasc' created."
+)
+# ==================================================================================================
+# INGEST BIODATA
+logging.info(
+    f"Beginning biodata ingestion for: '{BIODATA_FILE.as_posix()}'."
+)
+
+# BIODATA DATAFRAME COLUMN NAME MAPPING
+FEAT_TO_ECHOPOP_BIODATA_COLUMNS = {
+    "frequency": "length_count",
+    "haul": "haul_num",
+    "weight_in_haul": "weight",
+}
+
+# BIODATA LABEL MAPPING
+BIODATA_LABEL_MAP = {
+    "sex": {
+        1: "male",
+        2: "female",
+        3: "unsexed"
+    }
+}
+
+# READ IN DATA
+dict_df_bio = load_data.load_biological_data(
+    biodata_filepath=BIODATA_FILE, 
+    biodata_sheet_map=BIODATA_SHEETS_MAP, 
+    column_name_map=FEAT_TO_ECHOPOP_BIODATA_COLUMNS, 
+    subset_dict=BIODATA_MAPPING, 
+    biodata_label_map=BIODATA_LABEL_MAP
+)
+# ---- Remove specimen hauls
+biology.remove_specimen_hauls(dict_df_bio)
+logging.info(
+    "Biodata ingestion complete\n"
+    "'dict_df_bio' created."
+)
+# ==================================================================================================
+# AGE-1 DOMINATED HAUL REMOVAL
+if len(AGE1_DOMINATED_HAULS) > 0:
+    logging.info(
+        f"The following age-1 dominated haul numbers have been designated for removal from "
+        f"biodata:\n"
+        f"{', '.join(map(str, AGE1_DOMINATED_HAULS))}."
+    )
+    dict_df_bio = {
+        key: utils.apply_filters(dataset, exclude_filter={"haul_num": AGE1_DOMINATED_HAULS})
+        for key, dataset in dict_df_bio.items()
+    }
+    logging.info(
+        f"The following age-1 dominated haul numbers were successfully removed from the biodata:\n"
+        f"{', '.join(map(str, AGE1_DOMINATED_HAULS))}."
+    )
+# ==================================================================================================
+# INGEST STRATIFICATION DATA
+logging.info(
+    "Loading stratification files..."
+)
+# HAUL-BASED STRATIFICATION DATAFRAME COLUMN NAME MAPPING
+FEAT_TO_ECHOPOP_STRATA_COLUMNS = {
+    "fraction_hake": "nasc_proportion",
+    "haul": "haul_num",
+    "stratum": "stratum_num",
+}
+
+# READ IN STRATA FILE 
+logging.info(
+    f"Load in haul-based stratification: '{HAUL_STRATA_FILE.as_posix()}'."
+)
+df_dict_strata = load_data.load_strata(
+    strata_filepath=HAUL_STRATA_FILE, 
+    strata_sheet_map=HAUL_STRATA_SHEETS_MAP, 
+    column_name_map=FEAT_TO_ECHOPOP_STRATA_COLUMNS
+)
+logging.info(
+    "Haul-based stratification loading complete\n"
+    "'df_dict_strata' created."
+)
+
+# GEOGRAPHIC-BASED STRATIFICATION DATAFRAME COLUMN NAME MAPPING
+FEAT_TO_ECHOPOP_GEOSTRATA_COLUMNS = {
+    "latitude (upper limit)": "northlimit_latitude",
+    "stratum": "stratum_num",
+}
+
+# READ IN GEOSTRATA FILE
+logging.info(
+    f"Load in geographic-based stratification: '{GEOSTRATA_FILE.as_posix()}'."
+)
+df_dict_geostrata = load_data.load_geostrata(
+    geostrata_filepath=GEOSTRATA_FILE, 
+    geostrata_sheet_map=GEOSTRATA_SHEETS_MAP, 
+    column_name_map=FEAT_TO_ECHOPOP_GEOSTRATA_COLUMNS
+)
+logging.info(
+    "Geographic-based stratification loading complete\n"
+    "'df_dict_geostrata' created."
+)
+# ==================================================================================================
+# LOAD KRIGING MESH FILE
+logging.info(
+    f"Loading kriging mesh file: '{KRIGING_MESH_FILE.as_posix()}'."
+)
+
+# KRIGING MESH DATAFRAME COLUMN NAME MAPPING
+FEAT_TO_ECHOPOP_MESH_COLUMNS = {
+    "centroid_latitude": "latitude",
+    "centroid_longitude": "longitude",
+    "fraction_cell_in_polygon": "fraction",
+}
+
+# LOAD MESH
+df_mesh = load_data.load_mesh_data(
+    mesh_filepath=KRIGING_MESH_FILE, 
+    sheet_name=KRIGING_MESH_SHEET, 
+    column_name_map=FEAT_TO_ECHOPOP_MESH_COLUMNS
+)
+logging.info(
+    "Kriging mesh loading complete\n"
+    "'df_mesh' created."
+)
+# ==================================================================================================
+# LOAD ISOBATH FILE
+logging.info(
+    f"Loading isobath file: '{ISOBATH_FILE}'."
+)
+df_isobath = load_data.load_isobath_data(
+    isobath_filepath=ISOBATH_FILE,
+    sheet_name=ISOBATH_SHEET
+)
+logging.info(
+    f"Iosbath loading complete\n"
+    "'df_isobath' created."
+)
+# ==================================================================================================
+# LOAD KRIGING AND VARIOGRAM PARAMETERS
+logging.info(
+    f"Loading variogram and kriging parameters: '{KRIGING_VARIOGRAM_PARAMETERS_FILE.as_posix()}'."
+)
+
+# PARAMETERS DATAFRAME COLUMN NAME MAPPING
+FEAT_TO_ECHOPOP_GEOSTATS_PARAMS_COLUMNS = {
+    "hole": "hole_effect_range",
+    "lscl": "correlation_range",
+    "nugt": "nugget",
+    "powr": "decay_power",
+    "ratio": "aspect_ratio",
+    "res": "lag_resolution",
+    "srad": "search_radius",
+}
+
+# LOAD IN PARAMETERS
+dict_kriging_params, dict_variogram_params = load_data.load_kriging_variogram_params(
+    geostatistic_params_filepath=KRIGING_VARIOGRAM_PARAMETERS_FILE,
+    sheet_name=KRIGING_VARIGORAM_PARAMETERS_SHEET,
+    column_name_map=FEAT_TO_ECHOPOP_GEOSTATS_PARAMS_COLUMNS
+)
+logging.info(
+    "Variogram and kriging parameter loading complete\n"
+    "---- 'dict_variogram_params' created [variogram]\n"
+    "---- 'dict_kriging_params' created [kriging]"
+)
+# ==================================================================================================
+# INITIAL DATA PROCESSING
+# ==================================================================================================
+# APPLY STRATIFICATION DEFINITIONS TO BIODATA AND NASC
+logging.info("Applying strata to datasets...")
+
+# HAUL-BASED STRATA
+logging.info(
+    "Applying haul-based strata to 'dict_df_bio' and 'df_nasc'.\n"
+    "     Default stratum: 0\n"
+    "     New columns:\n"
+    "         INPFC: 'stratum_inpfc'\n"
+    "         KS: 'stratum_ks'"
+)
+# ---- BIODATA [INPFC]
+dict_df_bio = load_data.join_strata_by_haul(data=dict_df_bio,
+                                            strata_df=df_dict_strata["inpfc"],
+                                            default_stratum=0,
+                                            stratum_name="stratum_inpfc")
+# ---- BIODATA [KS]
+dict_df_bio = load_data.join_strata_by_haul(data=dict_df_bio,
+                                            strata_df=df_dict_strata["ks"],
+                                            default_stratum=0,
+                                            stratum_name="stratum_ks")
+# ---- NASC [INPFC]
+df_nasc = load_data.join_strata_by_haul(data=df_nasc,
+                                        strata_df=df_dict_strata["inpfc"],
+                                        default_stratum=0,
+                                        stratum_name="stratum_inpfc")
+# ---- NASC [KS]
+df_nasc = load_data.join_strata_by_haul(data=df_nasc,
+                                        strata_df=df_dict_strata["ks"],
+                                        default_stratum=0,
+                                        stratum_name="stratum_ks")
+
+# GEOGRAPHIC-BASED STRATA
+logging.info(
+    "Applying geographic-based strata to 'df_nasc' and 'df_mesh.\n"
+    "     New columns:\n"
+    "         INPFC: 'geostratum_inpfc'\n"
+    "         KS: 'geostratum_ks'"
+)
+# ---- NASC [INPFC]
+df_nasc = load_data.join_geostrata_by_latitude(data=df_nasc,
+                                               geostrata_df=df_dict_geostrata["inpfc"],
+                                               stratum_name="geostratum_inpfc")
+# ---- NASC [KS]
+df_nasc = load_data.join_geostrata_by_latitude(data=df_nasc,
+                                               geostrata_df=df_dict_geostrata["ks"],
+                                               stratum_name="geostratum_ks")
+# ---- MESH [INPFC]
+df_mesh = load_data.join_geostrata_by_latitude(data=df_mesh, 
+                                               geostrata_df=df_dict_geostrata["inpfc"], 
+                                               stratum_name="geostratum_inpfc")
+# ---- MESH [KS]
+df_mesh = load_data.join_geostrata_by_latitude(data=df_mesh, 
+                                               geostrata_df=df_dict_geostrata["ks"], 
+                                               stratum_name="geostratum_ks")
+logging.info("Strata application complete!")
+# ==================================================================================================
+# BINIFY DATA 
+logging.info(
+    "Binning biodata ['dict_df_bio'] into discrete age and length bins\n"
+    "     Age bins: [1, 2, 3, ..., 20, 21, 22]\n"
+    "     Length bins: [2.0, 4.0, 6.0, ... 76.0, 78.0, 80.0]\n"
+    "     New columns:\n"
+    "         Age: 'age_bin'\n"
+    "         Length: 'length_bin'"
+)
+
+# AGE-BINS
+AGE_BINS = np.linspace(start=1., stop=22, num=22)
+utils.binify(
+    data=dict_df_bio, bins=AGE_BINS, bin_column="age",
+)
+
+# LENGTH-BINS
+LENGTH_BINS = np.linspace(start=2., stop=80., num=40)
+utils.binify(
+    data=dict_df_bio, bins=LENGTH_BINS, bin_column="length", 
+)
+logging.info("Age and length binning complete!")
+# ==================================================================================================
+# FIT LENGTH-WEIGHT REGRESSION
+logging.info("Fitting length-weight regression for each sex and for all fish.")
+
+# CREATE DICTIONARY CONTAINER
+dict_length_weight_coefs = {}
+
+# ALL FISH
+dict_length_weight_coefs["all"] = dict_df_bio["specimen"].assign(sex="all").groupby(["sex"]).apply(
+    biology.fit_length_weight_regression,
+    include_groups=False
+)
+
+# SEX-SPECIFIC
+dict_length_weight_coefs["sex"] = dict_df_bio["specimen"].groupby(["sex"]).apply(
+    biology.fit_length_weight_regression,
+    include_groups=False
+)
+logging.info("Fitting length-weight regression for each sex and for all fish complete!")
+# ==================================================================================================
+# COMPUTE MEAN WEIGHTS PER LENGTH BIN
+logging.info(
+    "Computing the mean weight per length bin for each sex and for all fish.\n"
+    "     Impute missing length bins using modeled weights: True"
+    "     Minimum specimen count per bin: 5"
+    )
+
+# SEX-SPECIFIC
+df_binned_weights_sex = biology.length_binned_weights(
+    data=dict_df_bio["specimen"],
+    length_bins=LENGTH_BINS,
+    regression_coefficients=dict_length_weight_coefs["sex"],
+    impute_bins=True,
+    minimum_count_threshold=5
+)
+
+# ALL FISH
+df_binned_weights_all = biology.length_binned_weights(
+    data=dict_df_bio["specimen"].assign(sex="all"),
+    length_bins=LENGTH_BINS,
+    regression_coefficients=dict_length_weight_coefs["all"],
+    impute_bins=True,
+    minimum_count_threshold=5,
+)
+
+# COMBINE
+binned_weight_table = pd.concat([df_binned_weights_sex, df_binned_weights_all], axis=1)
+logging.info(
+    "Length-binned mean weight calculations complete\n"
+    "'binned_weight_table' created."
+    )
+# ==================================================================================================
+# COMPUTE COUNT DISTRIBUTIONS PER AGE- AND LENGTH-BINS
+logging.info(
+    "Computing the counts per age- and length-bins across sex.\n"
+    "     Stratifying by: 'stratum_ks'"
+    "     Grouping by: 'sex'"
+    )
+
+# DICTIONARY CONTAINER
+dict_df_counts = {}
+
+# AGED
+dict_df_counts["aged"] = get_proportions.compute_binned_counts(
+    data=dict_df_bio["specimen"].dropna(subset=["age", "length", "weight"]), 
+    groupby_cols=["stratum_ks", "length_bin", "age_bin", "sex"], 
+    count_col="length",
+    agg_func="size"
+)
+
+# UNAGED
+dict_df_counts["unaged"] = get_proportions.compute_binned_counts(
+    data=dict_df_bio["length"].copy().dropna(subset=["length"]), 
+    groupby_cols=["stratum_ks", "length_bin", "sex"], 
+    count_col="length_count",
+    agg_func="sum"
+)
+logging.info(
+    "Count distributions across age, length, and sex complete\n"
+    "'dict_df_counts' created."
+    )
+# ==================================================================================================
+# COMPUTE NUMBER PROPORTIONS
+logging.info(
+    "Computing number proportions across age and length bins\n"
+    "     Stratifying by: 'stratum_ks'\n"
+    "     Excluding: 'sex'='unsexed' from 'dict_df_counts['aged']'"
+    )
+dict_df_number_proportions = get_proportions.number_proportions(
+    data=dict_df_counts, 
+    group_columns=["stratum_ks"],
+    exclude_filters={"aged": {"sex": "unsexed"}},
+)
+logging.info(
+    "Number proportions calculation complete\n"
+    "'dict_df_number_proportions' created\n"
+    )
+# ==================================================================================================
+# COMPUTE BINNED WEIGHTS
+logging.info(
+    "Computing the summed weights per age- and length-bins across sex.\n"
+    "     Stratifying by: 'stratum_ks'"
+    "     Grouping by: 'sex'"
+    "     Excluding: 'sex'='unsexed'"
+    )
+
+# DICTIONARY CONTAINER
+dict_df_weight_distr = {}
+
+# AGED
+dict_df_weight_distr["aged"] = get_proportions.binned_weights(
+    length_dataset=dict_df_bio["specimen"],
+    include_filter = {"sex": ["female", "male"]},
+    interpolate_regression=False,
+    contrast_vars="sex",
+    table_cols=["stratum_ks", "sex", "age_bin"]
+)
+
+# UNAGED
+logging.info(
+    "Unaged binned weights require additional processing steps.\n"
+    "     Interpolating binned length-weight regression estimates: True"
+    )
+dict_df_weight_distr["unaged"] = get_proportions.binned_weights(
+    length_dataset=dict_df_bio["length"],
+    length_weight_dataset=binned_weight_table,
+    include_filter = {"sex": ["female", "male"]},
+    interpolate_regression=True,
+    contrast_vars="sex",
+    table_cols=["stratum_ks", "sex"]
+)
+logging.info(
+    "Summed weights per age- and length-bins across sex computation complete\n"
+    "'dict_df_weight_distr' created."
+    )
+# ==================================================================================================
+# COMPUTE WEIGHT PROPORTIONS
+logging.info(
+    "Computing weight proportions across age and length bins\n"
+    "     Stratifying by: 'stratum_ks'"
+    "     Grouping by: 'sex'"
+    )
+
+# DICTIONARY CONTAINER
+dict_df_weight_proportions = {}
+
+# AGED WEIGHT PROPORTIONS
+logging.info("Computing aged weight proportions...")
+dict_df_weight_proportions["aged"] = get_proportions.weight_proportions(
+    weight_data=dict_df_weight_distr, 
+    catch_data=dict_df_bio["catch"], 
+    group="aged",
+    stratum_col="stratum_ks"
+)
+
+# UNAGED SCALING
+logging.info("Scaling unaged binned weights...")
+standardized_sexed_unaged_weights_df = get_proportions.scale_weights_by_stratum(
+    weights_df=dict_df_weight_distr["unaged"], 
+    reference_weights_df=dict_df_bio["catch"].groupby(["stratum_ks"])["weight"].sum(),
+    stratum_col="stratum_ks",
+)
+
+# UNAGED WEIGHT PROPORTIONS
+logging.info(
+    "Computing unaged weight proportions\n"
+    "     Scaling weight proportions in reference to the aged estimates"
+    )
+dict_df_weight_proportions["unaged"] = get_proportions.scale_weight_proportions(
+    weight_data=standardized_sexed_unaged_weights_df, 
+    reference_weight_proportions=dict_df_weight_proportions["aged"], 
+    catch_data=dict_df_bio["catch"], 
+    number_proportions=dict_df_number_proportions,
+    binned_weights=binned_weight_table["all"],
+    group="unaged",
+    group_columns = ["sex"],
+    stratum_col = "stratum_ks"
+)
+logging.info(
+    "Weight proportions calculation complete\n"
+    "'dict_df_weight_proportions' created."
+    )
+# ==================================================================================================
+# NASC TO BIOMASS CONVERSION
+# ==================================================================================================
+# INVERSION
+logging.info(
+    "Beginning inversion based on hake-specific TS-length regression coefficients\n"
+    "     Model: 20.0 x log[10](L) + -68.0\n"
+    "     Stratifying by: 'stratum_ks'\n"
+    "     Imputing missing strata: True\n"
+    "     Treating hauls as replicates: True"
+    )
+
+# DEFINE INVERSION MODEL PARAMETERS
+MODEL_PARAMETERS = {
+    "ts_length_regression": {
+        "slope": 20.,
+        "intercept": -68.
+    },
+    "stratify_by": ["stratum_ks"],
+    "expected_strata": df_dict_strata["ks"].stratum_num.unique(),
+    "impute_missing_strata": True,
+    "haul_replicates": True,
+}
+
+# INITIALIZE INVERSION OBJECT
+invert_hake = inversion.InversionLengthTS(MODEL_PARAMETERS)
+logging.info("Inversion-class object 'invert_hake' created...")
+
+# INVERT NUMBER DENSITY
+df_nasc = invert_hake.invert(
+    df_nasc=df_nasc, df_length=[dict_df_bio["length"], dict_df_bio["specimen"]]
+)
+logging.info(
+    "Number density inversion complete\n"
+    "     New column in 'df_nasc':\n"
+    "         Number density (animals nm^-2): 'number_density'"
+    )
+# ==================================================================================================
+# CONVERT TO BIOMASS
+logging.info("Converting number density estimates into biomass estimates")
+
+# SET TRANSECT INTERVAL DISTANCES
+logging.info(
+    "Defining transect interval distances...\n"
+    "     Along-transect interval distance (nmi) threshold: 0.5 nmi"
+)
+transect.compute_interval_distance(df_nasc=df_nasc, interval_threshold=0.05)
+
+# SET TRANSECT INTERVAL AREAS
+logging.info("Defining transect interval areas...")
+df_nasc["area_interval"] = (
+    df_nasc["transect_spacing"] * df_nasc["distance_interval"]
+)
+
+# COMPUTE ABUNDANCE
+logging.info(
+    "Compute interval abundances...\n"
+    "     Stratifying by: 'stratum_ks'\n"
+    "     Grouping by: 'sex'\n"
+    "     Excluding: 'sex'='unsexed' from 'dict_df_number_proportions'"    
+)
+biology.compute_abundance(
+    dataset=df_nasc,
+    stratify_by=["stratum_ks"],
+    group_by=["sex"],
+    exclude_filter={"sex": "unsexed"},
+    number_proportions=dict_df_number_proportions
+)
+
+# COMPUTE STRATUM-AVERAGED WEIGHTS
+df_averaged_weight = get_proportions.stratum_averaged_weight(
+    proportions_dict=dict_df_number_proportions, 
+    binned_weight_table=binned_weight_table,
+    stratify_by=["stratum_ks"],
+    group_by=["sex"],
+)
+
+# COMPUTE BIOMASS
+logging.info(
+    "Compute interval biomass...\n"
+    "     Stratifying by: 'stratum_ks'\n"
+    "     Grouping by: 'sex'\n"  
+)
+biology.compute_biomass(
+    dataset=df_nasc,
+    stratify_by=["stratum_ks"],
+    group_by=["sex"],
+    df_average_weight=df_averaged_weight,
+)
+logging.info(
+    "NASC to biomass conversion complete\n"
+    "     New columns in 'df_nasc':\n"
+    "         Sex-specific number densities (animals nmi^-2): "
+    "'number_density_female'/'number_density_male'\n"
+    "         Abundance (animals): 'abundance'/'abundance_female'/'abundance_male'\n"
+    "         Biomass density (kg nmi^-2): 'biomass_density'/'biomass_density_female'/"
+    "'biomass_density_male'\n"
+    "         Biomass (kg): 'biomass'/'biomass_female'/'biomass_male'"
+    )
+# ==================================================================================================
+# AGE-1 CONTRIBUTION REMOVAL
+logging.info(
+    "Removing age-1 contributions from NASC, abundance, and biomass estimates...\n"
+    "     Stratifying by: 'stratum_ks'\n"
+    "     Minimum length threshold for weight proportions: 10.0 cm\n"
+    "     Minimum weight proportion threshold: 1E-10"  
+)
+
+# NASC
+age1_nasc_proportions = get_proportions.get_nasc_proportions_slice(
+    number_proportions=dict_df_number_proportions["aged"],
+    stratify_by=["stratum_ks"],
+    ts_length_regression_parameters={"slope": 20., 
+                                     "intercept": -68.},
+    include_filter = {"age_bin": [1]}
+)
+
+# NUMBER
+age1_number_proportions = get_proportions.get_number_proportions_slice(
+    number_proportions=dict_df_number_proportions["aged"],
+    stratify_by=["stratum_ks"],
+    include_filter = {"age_bin": [1]}
+)
+
+# WEIGHT
+age1_weight_proportions = get_proportions.get_weight_proportions_slice(
+    weight_proportions=dict_df_weight_proportions["aged"],
+    stratify_by=["stratum_ks"],
+    include_filter={"age_bin": [1]},
+    number_proportions=dict_df_number_proportions,
+    length_threshold_min=10.0,
+    weight_proportion_threshold=1e-10
+)
+
+# APPLY REMOVAL
+df_nasc_noage1 = apportion.remove_group_from_estimates(
+    transect_data=df_nasc,
+    group_proportions={
+        "nasc": age1_nasc_proportions, 
+        "abundance": age1_number_proportions,
+        "biomass": age1_weight_proportions
+    },
+)
+logging.info(
+    "Age-1 contribution removal complete\n"
+    "'df_nasc_noage1' created."
+    )
+# ==================================================================================================
+# DISTRIBUTE POPULATION ESTIMATES ACROSS AGE AND LENGTH BINS
+logging.info(
+    "Distribute population estimates across age- and length-bins\n"
+    "     Stratifying by: 'stratum_ks'\n"
+    "     Grouping by: 'sex'"
+)
+
+# ABUNDANCE
+logging.info("Distributing abundances...")
+dict_transect_abundance_table = apportion.distribute_population_estimates(
+    data=df_nasc,
+    proportions=dict_df_number_proportions,
+    variable="abundance",
+    group_by=["sex", "age_bin", "length_bin"],
+    stratify_by=["stratum_ks"],
+)
+logging.info("Abundance distributions complete\n'dict_transect_abundance_table' created.")
+# BIOMASS [ALL]
+logging.info("Distributing biomass...")
+dict_transect_biomass_table = apportion.distribute_population_estimates(
+    data=df_nasc,
+    proportions=dict_df_weight_proportions,
+    variable="biomass",
+    group_by=["sex", "age_bin", "length_bin"],
+    stratify_by=["stratum_ks"],
+)
+logging.info("Biomass distribution complete\n'dict_transect_biomass_table' created.")
+# BIOMASS [AGED-ONLY]
+logging.info("Distributing biomass...\n     Aged-only weight proportions: True")
+df_transect_aged_biomass_table = apportion.distribute_population_estimates(
+    data=df_nasc,
+    proportions=dict_df_weight_proportions["aged"],
+    variable="biomass",
+    group_by=["sex", "age_bin", "length_bin"],
+    stratify_by=["stratum_ks"],
+)
+logging.info("Aged-biomass distribution complete\n'df_transect_aged_biomass_table' created.")
+# ==================================================================================================
+# GEOSTATISTICS
+# ==================================================================================================
+# INITIAL
+logging.info("Beginning geostatistical analysis...")
+# ==================================================================================================
+# COORDINATE TRANSFORMATION
+logging.info(
+    "Transform spatial coordinates for 'df_nasc_noage1' and 'df_mesh'\n"
+    "     Reference coordinates: 'df_isobath'\n"
+    "     Longitudinal offset: -124.78338 deg.E\n"
+    "     Latitudinal offset: 45.0 deg.N"
+)
+
+# NASC
+df_nasc_noage1, delta_longitude, delta_latitude = spatial.transform_coordinates(
+    data = df_nasc_noage1,
+    reference = df_isobath,
+    x_offset = -124.78338,
+    y_offset = 45.,   
+)
+
+# MESH
+df_mesh, _, _ = spatial.transform_coordinates(
+    data = df_mesh,
+    reference = df_isobath,
+    x_offset = -124.78338,
+    y_offset = 45.,   
+    delta_x=delta_longitude,
+    delta_y=delta_latitude
+)
+logging.info(
+    "Coordinate transformation complete\n"
+    "     New columns:\n"
+    "          Transformed longitude: 'x'\n"
+    "          Transformed latitude: 'y'\n"
+)
+# ==================================================================================================
+# VARIOGRAM ANALYSIS
+logging.info(
+    "Beginning variogram analysis\n"
+    "     Normalized lag resolution: 0.002\n"
+    "     Number of lags: 30\n"
+)
+
+# INITIALIZE VARIOGRAM-CLASS OBJECT
+vgm = variogram.Variogram(
+    lag_resolution=0.002,
+    n_lags=30,
+    coordinate_names=("x", "y"),
+)
+logging.info("Variogram-class object 'vgm' created...")
+
+# EMPIRICAL VARIOGRAM
+logging.info(
+    "Computing the empirical variogram\n"
+    "     Variable: 'biomass_density'\n"
+    "     Applying azimuth angle filter: True\n"
+    "     Azimuth angle filter: 180.0 deg.\n"
+)
+vgm.calculate_empirical_variogram(
+    data=df_nasc_noage1,
+    variable="biomass_density",
+    azimuth_filter=True,
+    azimuth_angle_threshold=180.,
+)
+
+# SET UP FITTING PARAMETERS
+# ----- lmfit.Parameters tuples: (NAME VALUE VARY MIN  MAX  EXPR  BRUTE_STEP)
+logging.info(
+    f"Optimizing variogram parameters using non-linear least-squares\n"
+    f"     Model: Exponential-Bessel (['exponential', 'bessel'])\n"
+    f"     Initial values:\n"
+    f"          Nugget: {dict_variogram_params["nugget"]}\n"
+    f"          Sill: {dict_variogram_params["sill"]}\n"
+    f"          Correlation range: {dict_variogram_params["correlation_range"]}\n"
+    f"          Hole effect range: {dict_variogram_params["hole_effect_range"]}\n"
+    f"          Decay power exponent: {dict_variogram_params["decay_power"]}"
+)
+variogram_parameters_lmfit = Parameters()
+variogram_parameters_lmfit.add_many(
+    ("nugget", dict_variogram_params["nugget"], True, 0.),
+    ("sill", dict_variogram_params["sill"], True, 0.),
+    ("correlation_range", dict_variogram_params["correlation_range"], True, 0.),
+    ("hole_effect_range", dict_variogram_params["hole_effect_range"], True, 0.),
+    ("decay_power", dict_variogram_params["decay_power"], True, 1.25, 1.75),
+)
+
+# OPTIMIZATION PARAMETERS
+OPTIM_ARGS = {
+    "max_nfev": None, "ftol": 1e-08, "gtol": 1e-8, "xtol": 1e-8, "diff_step": None, 
+    "tr_solver": "exact", "x_scale": 1., "jac": "2-point"
+}
+logging.info(
+    f"Optimization arguments:\n"
+    f"{OPTIM_ARGS}"
+)
+
+# RUN MINIMIZER
+best_fit_parameters = vgm.fit_variogram_model(
+    model=["exponential", "bessel"],
+    model_parameters=variogram_parameters_lmfit,
+    optimizer_kwargs=OPTIM_ARGS,
+)
+logging.info(
+    f"Variogram parameter fitting complete\n"
+    f"     Best-fit parameters:\n"
+    f"     {best_fit_parameters}"
+)
+# ==================================================================================================
+# KRIGING ANALYSIS
+logging.info(
+    f"Beginning kriging analysis\n"
+    f"     Using best-fit variogram model and parameters: True\n"
+    f"     Kriging parameters:\n"
+    f"          Normalized search radius: {best_fit_parameters["correlation_range"] * 3}\n"
+    f"          Minimum nearest-neighbor count: 3\n"
+    f"          Maximum nearest-neighbor count: 10\n"
+    f"          Anisotropic aspect ratio: 0.001"
+)
+
+# KRIGING PARAMETERS CONTAINER
+KRIGING_PARAMETERS = {
+    "search_radius": best_fit_parameters["correlation_range"] * 3,
+    "aspect_ratio": 0.001,
+    "k_min": 3,
+    "k_max": 10,
+}  
+
+# VARIOGRAM PARAMETERS CONTAINER
+VARIOGRAM_PARAMETERS = {
+    "model": ["exponential", "bessel"],
+    **best_fit_parameters
+}
+
+# INITIALIZE CLASS OBJECT
+krg = kriging.Kriging(
+    mesh=df_mesh,
+    kriging_params=KRIGING_PARAMETERS,
+    variogram_params=VARIOGRAM_PARAMETERS,
+    coordinate_names=("x", "y"),
+)
+logging.info("Kriging-class object 'krg' created...")
+
+# RUN KRIGING
+logging.info(
+    "Interpolating population estimates using ordinary kriging\n"
+    "     Variable: 'biomass_density'\n"
+    "     Extrapolation (full mesh): True\n"
+    "     Default mesh cell area: 6.25 nmi^2\n"
+)
+df_kriged_results = krg.krige(
+    transects=df_nasc_noage1,
+    variable="biomass_density",
+    extrapolate=True,
+    default_mesh_cell_area=6.25,
+)
+logging.info(
+    f"Kriging complete\n"
+    f"'df_kriged_results' created."
+)
+# ==================================================================================================
+# CONVERT BIOMASS DENSITY TO NASC
+logging.info(
+    "Converting biomass density estimates into NASC\n"
+    "     Stratifying by: 'geostratum_ks'/'stratum_ks'\n"
+    "     Grouping by: 'sex'\n"
+    "     Using stratum weights for all fish: True"
+)
+
+# CONVERT TO BIOMASS
+df_kriged_results["biomass"] = df_kriged_results["biomass_density"] * df_kriged_results["area"]
+logging.info("New column in 'df_kriged_results': 'biomass'")
+
+# BIOMASS TO NASC
+apportion.mesh_biomass_to_nasc(
+    mesh_data_df=df_kriged_results,
+    biodata=dict_df_weight_proportions,
+    group_by=["sex"],
+    mesh_biodata_link={"geostratum_ks": "stratum_ks"},
+    stratum_weights_df=df_averaged_weight["all"],
+    stratum_sigma_bs_df=invert_hake.sigma_bs_strata,    
+)
+logging.info(
+    "Biomass density to NASC conversion complete\n"
+    "    New columns in `df_kriged_results`\n"
+    "        Biomass (kg): 'biomass'/'biomass_female'/'biomass_male'\n"
+    "        Abundance (animals): 'abundance'/'abundance_female'/'abundance_male'\n"
+    "        NASC (m^2 nmi^-2): 'nasc'"
+)
+# ==================================================================================================
+# DISTRIBUTE POPULATION ESTIMATES ACROSS AGE AND LENGTH BINS
+logging.info(
+    "Distribute kriged population estimates across age- and length-bins\n"
+    "     Stratifying by: 'stratum_ks'\n"
+    "     Grouping by: 'sex'"
+)
+
+# ABUNDANCE [ALL]
+logging.info("Distributing abundances...")
+dict_kriged_abundance_table = apportion.distribute_population_estimates(
+    data=df_kriged_results,
+    proportions=dict_df_number_proportions,
+    variable="abundance",
+    group_by=["sex", "age_bin", "length_bin"],
+    stratify_by=["stratum_ks"],
+    data_proportions_link={"geostratum_ks": "stratum_ks"},
+)
+logging.info("Abundance distributions complete\n'dict_kriged_abundance_table' created.")
+
+# SCALE UNAGED ABUNDANCE
+logging.info(
+    "Scaling unaged abundance...\n"     
+    "     Reference: Aged abundances\n"
+    "     Imputing missing bins: False"
+)
+dict_kriged_abundance_table["standardized_unaged"] = apportion.distribute_unaged_from_aged(
+    population_table=dict_kriged_abundance_table["unaged"],
+    reference_table=dict_kriged_abundance_table["aged"],
+    group_by=["sex"],
+    impute=False,    
+)
+
+# BIOMASS [ALL]
+logging.info("Distributing biomass...")
+dict_kriged_biomass_table = apportion.distribute_population_estimates(
+    data=df_kriged_results,
+    proportions=dict_df_weight_proportions,
+    variable="biomass",
+    group_by=["sex", "age_bin", "length_bin"],
+    stratify_by=["stratum_ks"],
+    data_proportions_link={"geostratum_ks": "stratum_ks"},
+)
+logging.info("Biomass distribution complete\n'dict_kriged_biomass_table' created.")
+
+# SCALE UNAGED BIOMASS
+logging.info(
+    "Scaling unaged biomass...\n"     
+    "     Reference: Aged biomass\n"
+    "     Imputing missing bins: True"
+)
+dict_kriged_biomass_table["standardized_unaged"] = apportion.distribute_unaged_from_aged(
+    population_table=dict_kriged_biomass_table["unaged"],
+    reference_table=dict_kriged_biomass_table["aged"],
+    group_by=["sex"],
+    impute=True,
+    impute_variable=["age_bin"],
+)
+
+# CONSOLIDATE
+# ---- ABUNDANCE
+logging.info("Consolidating abundance tables...")
+df_kriged_abundance_table = apportion.sum_population_tables(
+    population_table=dict_kriged_abundance_table,
+    table_names=["aged", "standardized_unaged"],
+    table_index=["length_bin"],
+    table_columns=["age_bin", "sex"],
+)
+logging.info("Abundance table complete\n'df_kriged_abundance_table' created.")
+# ---- Biomass
+logging.info("Consolidating biomass tables...")
+df_kriged_biomass_table = apportion.sum_population_tables(
+    population_table=dict_kriged_biomass_table,
+    table_names=["aged", "standardized_unaged"],
+    table_index=["length_bin"],
+    table_columns=["age_bin", "sex"],
+)
+logging.info("Biomass table complete\n'df_kriged_biomass_table' created.")
+
+# REDISTRIBUTE AGE-1 ABUNDANCES
+logging.info("Redistributing kriged age-1 abundances and biomasses...")
+df_kriged_abundance_table_noage1 = apportion.reallocate_excluded_estimates(
+    population_table=df_kriged_abundance_table,
+    exclusion_filter={"age_bin": [1]},
+    group_by=["sex"],
+)
+
+# REDISTRIBTUE AGE-1 BIOMASS
+df_kriged_biomass_table_noage1 = apportion.reallocate_excluded_estimates(
+    population_table=df_kriged_biomass_table,
+    exclusion_filter={"age_bin": [1]},
+    group_by=["sex"],
+)
+logging.info(
+    "Kriged age-1 abundance and biomass estimates redistributed\n"
+    "'df_kriged_abundance_table_noage1' and 'df_kriged_biomass_table_noage1' created."
+)
+# ==================================================================================================
+# JOLLY AND HAMPTON (1990) ANALYSIS
+# ==================================================================================================
+logging.info("Beginning stratified analysis to estimate uncertainties (Jolly and Hampton, 1990)...")
+
+# ANALYSIS PARAMETERS CONTAINER
+JOLLYHAMPTON_PARAMETERS = {
+    "transects_per_latitude": 5,
+    "strata_transect_proportion": 0.75,
+    "num_replicates": 1000,
+}
+
+# INITIALIZE JOLLYHAMPTON CLASS OBJECT
+jh = stratified.JollyHampton(JOLLYHAMPTON_PARAMETERS)
+logging.info("Stratified-analysis-class object 'jh' created...")
+
+# RUN ON TRANSECT DATA
+logging.info(
+    "Running Jolly and Hampton (1990) algorithm for transect data\n"
+    "     Variable: 'biomass'\n"
+    "     Number of bootstrap replicates: 1000\n"
+    "     Stratum transect sampling proportion: 0.75\n"
+    "     Stratifying by: 'geostratum_ks'"
+)
+jh.stratified_bootstrap(data_df=df_nasc_noage1, 
+                        stratify_by=["geostratum_inpfc"], 
+                        variable="biomass")
+logging.info(
+    "Summarizing results....\n"
+    "     Confindence interval percentile: 0.95\n"
+    "     Confidence interval method: Jackknife studentized interval ('t-jackknife')"
+)
+df_jh_transect_results = jh.summarize(ci_percentile=0.95, ci_method="t-jackknife")
+logging.info("Stratified transect analysis results complete\n'df_jh_transect_results' created.")
+
+# RUN ON KRIGED DATA
+# ---- Create virtual transects
+logging.info(
+    "Creating virtual transects for kriged mesh data\n"
+    "     Stratifying by: 'geostratum_inpfc'\n"
+    "     Virtual transects per latitude: 5"
+)
+kriged_transects = jh.create_virtual_transects(
+    data_df=df_kriged_results,
+    geostrata_df=df_dict_geostrata["inpfc"], 
+    stratify_by=["geostratum_inpfc"],
+    variable="biomass",
+)
+# ---- Run rest of flow
+logging.info(
+    "Running Jolly and Hampton (1990) algorithm for kriged data\n"
+    "     Variable: 'biomass'\n"
+    "     Number of bootstrap replicates: 1000\n"
+    "     Virtual transect sampling proportion: 0.75\n"
+    "     Stratifying by: 'geostratum_ks'"
+)
+jh.stratified_bootstrap(data_df=kriged_transects, 
+                        stratify_by=["geostratum_inpfc"], 
+                        variable="biomass")
+logging.info(
+    "Summarizing results....\n"
+    "     Confindence interval percentile: 0.95\n"
+    "     Confidence interval method: Jackknife studentized interval ('t-jackknife')"
+)
+df_jh_kriged_results = jh.summarize(ci_percentile=0.95, ci_method="t-jackknife")
+logging.info("Stratified kriged analysis results complete\n'df_jh_kriged_results' created.")

--- a/echopop/workflow/feat_hake_kriging_without_extrapolation.py
+++ b/echopop/workflow/feat_hake_kriging_without_extrapolation.py
@@ -1,0 +1,1009 @@
+####################################################################################################
+# FEAT hake survey: kriging population estimates without mesh cropping
+# --------------------------------------------------------------------
+from pathlib import Path
+from echopop.nwfsc_feat import FEAT
+####################################################################################################
+# PARAMETER ENTRY
+# ---------------
+# ** ENTER FILE INFORMATION FOR ALL INGESTED DATASETS.
+# ** ADDITIONAL PARAMETERIZATIONS THROUGHOUT THE SCRIPT SHOULD BE EDITED BASED ON SPECIFIC NEEDS. 
+# ** MAKE SURE TO EDIT WITH CARE.
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# PRINT CONSOLE LOGGING MESSAGES
+# ---- When set to `True`, logging information will be printed in the terminal/console as the 
+# ---- script progresses
+VERBOSE = True
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# DATA ROOT DIRECTORY
+DATA_ROOT = Path("C:/Users/Brandyn Lucca/Documents/Data/echopop_2019")
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# ALREADY PROCESSED NASC FILE ? 
+# ---- When False, the raw NASC exports will be processed. When True, the pre-formatted NASC 
+# ---- spreadsheet will be read in. This also requires defining `NASC_EXPORTS_SHEET`
+NASC_PREPROCESSED = False
+# NASC EXPORTS FILE(S)
+NASC_EXPORTS_FILES = DATA_ROOT / "raw_nasc/"
+# NASC EXPORTS SHEET
+NASC_EXPORTS_SHEET = "Sheet1"
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# BIODATA FILE
+BIODATA_FILE = DATA_ROOT / "Biological/1995-2023_biodata_redo.xlsx"
+# BIODATA SHEETS
+# ---- Assign the sheetnames to 'catch', 'length', 'specimen'
+BIODATA_SHEETS_MAP = {
+    "catch": "biodata_catch",
+    "length": "biodata_length",
+    "specimen": "biodata_specimen",
+}
+# BIODATA PROCESSING: MASTER SPREADSHEET PARSING
+# ---- This is used to parse the biodata master spreadsheet, which is required for aligning the 
+# ---- biodata with ancillary files such as stratification and transect-haul mappings. This should 
+# ---- define the "ships" based on their IDs with the associated survey IDs. If an offset should be 
+# ---- added to the haul numbers, that must also be defined here. The target species should also be 
+# ---- defined here. 
+BIODATA_MAPPING = {
+    "ships": {
+        160: {
+            "survey": 202106
+        },
+        584: {
+            "survey": 202113,
+            "haul_offset": 200
+        }
+    },
+    "species_code": [22500]
+}
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# HAUL STRATIFICATION FILE
+HAUL_STRATA_FILE = DATA_ROOT / "Stratification/US_CAN strata 2019_final.xlsx"
+# HAUL STRATIFICATION SHEET MAP
+# ---- Valid keys are limited to "ks" and "inpfc"
+HAUL_STRATA_SHEETS_MAP = {
+    "inpfc": "INPFC",
+    "ks": "Base KS",
+}
+# GEOGRAPHIC STRATIFICATION FILE
+GEOSTRATA_FILE = DATA_ROOT / "Stratification/Stratification_geographic_Lat_2019_final.xlsx"
+# GEOGRAPHIC STRATIFICATION SHEET MAP
+# ---- Valid keys are limited to "ks" and "inpfc"
+GEOSTRATA_SHEETS_MAP = {
+    "inpfc": "INPFC",
+    "ks": "stratification1",
+}
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# KRIGING MESH FILE 
+KRIGING_MESH_FILE = (
+    DATA_ROOT / "Kriging_files/Kriging_grid_files/krig_grid2_5nm_cut_centroids_2013.xlsx"
+)
+# KRIGING MESH SHEET
+KRIGING_MESH_SHEET = "krigedgrid2_5nm_forChu"
+# KRIGING MESH PROCESSING: CROP METHOD
+# ---- This should be a Callable function. When cropping, this typically defaults to using a convex 
+# ---- hull method. However, custom functions can be called, such as cropping based on the 
+# ---- interpolated boundaries of the survey region. These custom functions can be found in the 
+# ---- `FEAT.fun` module.
+CROP_METHOD = FEAT.fun.transect_ends_crop
+# KRIGING MESH PROCESSING: CROPPING FUNCTION PARAMETERS
+# ---- For the FEAT-specific `transect_ends_crop` function, a transect-region mapping function 
+# ---- must be provided. These can be year-specific and can be found in the `FEAT.parameters` 
+# ---- module. This transect mesh region mapping function tracks the original transect region 
+# ---- definition files used in the MATLAB EchoPro distribution.
+TRANSECT_MESH_REGION_MAP = FEAT.parameters.transect_mesh_region_2019
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# KRIGING AND VARIOGRAM PARAMETERS FILE
+KRIGING_VARIOGRAM_PARAMETERS_FILE = (
+    DATA_ROOT / "Kriging_files/default_vario_krig_settings_2019_US_CAN.xlsx"
+)
+# KRIGING AND VARIOGRAM PARAMETERS SHEET
+KRIGING_VARIGORAM_PARAMETERS_SHEET = "Sheet1"
+# KRIGING ALGORITHM: NEAREST NEIGHBORS SEARCH STRATEGY
+# ---- The default nearest neighbor search strategy used by the ordinary kriging algorithm is a 
+# ---- uniform method. The FEAT-specific method based on the western extent of the survey region 
+# ---- can be found in the `FEAT.fun` module.
+KRIGING_SEARCH_STRATEGY = FEAT.western_boundary_search_strategy
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# 200m ISOBATH FILE
+ISOBATH_FILE = (
+    DATA_ROOT / "Kriging_files/Kriging_grid_files/transformation_isobath_coordinates.xlsx"
+)
+# 200m ISOBATH SHEET
+ISOBATH_SHEET = "Smoothing_EasyKrig"
+####################################################################################################
+####################################################################################################
+# !!! START OF PROCESSING SCRIPT !!
+# !!! EDIT CODE BELOW WITH CARE !!
+####################################################################################################
+####################################################################################################
+import logging
+import numpy as np
+import pandas as pd
+from lmfit import Parameters
+from echopop import inversion
+from echopop.nwfsc_feat import (
+    apportion,
+    biology, 
+    ingest_nasc, 
+    get_proportions, 
+    kriging,
+    load_data, 
+    spatial,
+    transect, 
+    utils,
+    variogram
+)
+####################################################################################################
+# FORMAT LOGGER
+for handler in logging.root.handlers[:]:
+    logging.root.removeHandler(handler)
+    
+logging.basicConfig(
+    level=logging.INFO if VERBOSE else logging.WARNING,
+    format="%(message)s")
+# ==================================================================================================
+# DATA INGESTION 
+# ==================================================================================================
+# INGEST NASC DATA 
+if NASC_PREPROCESSED:
+    logging.info(f"Reading pre-generated NASC export file: '{NASC_EXPORTS_FILES.as_posix()}'.")
+
+    # DEFINE COLUMN MAPPING
+    FEAT_TO_ECHOPOP_COLUMNS = {
+        "transect": "transect_num",
+        "region id": "region_id",
+        "vessel_log_start": "distance_s",
+        "vessel_log_end": "distance_e",
+        "spacing": "transect_spacing",
+        "layer mean depth": "layer_mean_depth",
+        "layer height": "layer_height",
+        "bottom depth": "bottom_depth",
+        "assigned haul": "haul_num",
+    }
+
+    # Read file
+    df_nasc = ingest_nasc.read_nasc_file(
+        filename=NASC_EXPORTS_FILES,
+        sheetname=NASC_EXPORTS_SHEET,
+        column_name_map=FEAT_TO_ECHOPOP_COLUMNS
+    )
+else:
+    logging.info(
+        f"Beginning NASC export ingestion for files in: '{NASC_EXPORTS_FILES.as_posix()}'."
+    )
+
+    # MERGE EXPORTS
+    logging.info(
+        "---- Merging NASC exports...\n"
+        "     Filename transect pattern: 'T(\\d+)'\n"
+        "     Default transect spacing: 10.0 nmi\n"
+        "     Default latitude threshold: 60.0 deg."
+    )    
+    df_intervals, df_exports = ingest_nasc.merge_echoview_nasc(
+        nasc_path = NASC_EXPORTS_FILES,
+        filename_transect_pattern = r"T(\d+)",
+        default_transect_spacing = 10.0,
+        default_latitude_threshold = 60.0,
+    )
+
+    # EXPORT REGION NAME MAPPING
+    REGION_NAME_EXPR_DICT = {
+        "REGION_CLASS": {
+            "Age-1 Hake": "^(?:h1a(?![a-z]|m))",
+            "Age-1 Hake Mix": "^(?:h1am(?![a-z]|1a))",
+            "Hake": "^(?:h(?![a-z]|1a)|hake(?![_]))",
+            "Hake Mix": "^(?:hm(?![a-z]|1a)|hake_mix(?![_]))",
+        },
+        "HAUL_NUM": {
+            "[0-9]+",
+        },
+        "COUNTRY": {
+            "CAN": "^[cC]",
+            "US": "^[uU]",
+        },
+    }    
+    
+    # PROCESS REGION NAMES 
+    logging.info(
+        "---- Processing export region names\n"
+        "     Applying CAN haul number offset: 200"
+    )
+    df_exports_with_regions = ingest_nasc.process_region_names(
+        df=df_exports,
+        region_name_expr_dict=REGION_NAME_EXPR_DICT,
+        can_haul_offset=200,
+    )
+
+    # GENERATE TRANSECT-REGION-HAUL KEY
+    logging.info(
+        "---- Generating transect-region-haul key mapping\n"
+        "     Searching for the export regions: 'Age-1 Hake', 'Age-1 Hake Mix', 'Hake', 'Hake Mix'"
+    )
+    df_transect_region_haul_key = ingest_nasc.generate_transect_region_haul_key(
+        df=df_exports_with_regions,
+        filter_list=["Age-1 Hake", "Age-1 Hake Mix", "Hake", "Hake Mix"]
+    )
+
+    # CONSOLIDATE THE EXPORTS WITH TRANSECT-REGION-HAUL MAPPINGS
+    logging.info(
+        "---- Finalizing NASC export ingestion\n"
+        "     Searching for the export regions: 'Age-1 Hake', 'Age-1 Hake Mix', 'Hake', 'Hake Mix'"
+        "     Imputing overlapping region IDs within each interval: True"
+    )
+    df_nasc = ingest_nasc.consolidate_echvoiew_nasc(
+        df_merged=df_exports_with_regions,
+        interval_df=df_intervals,
+        region_class_names=["Age-1 Hake", "Age-1", "Age-1 Hake Mix", "Hake", "Hake Mix"],
+        impute_region_ids=True,
+        transect_region_haul_key_df=df_transect_region_haul_key
+    )
+logging.info(
+    "NASC ingestion complete\n"
+    "'df_nasc' created."
+)
+# ==================================================================================================
+# INGEST BIODATA
+logging.info(
+    f"Beginning biodata ingestion for: '{BIODATA_FILE.as_posix()}'."
+)
+
+# BIODATA DATAFRAME COLUMN NAME MAPPING
+FEAT_TO_ECHOPOP_BIODATA_COLUMNS = {
+    "frequency": "length_count",
+    "haul": "haul_num",
+    "weight_in_haul": "weight",
+}
+
+# BIODATA LABEL MAPPING
+BIODATA_LABEL_MAP = {
+    "sex": {
+        1: "male",
+        2: "female",
+        3: "unsexed"
+    }
+}
+
+# READ IN DATA
+dict_df_bio = load_data.load_biological_data(
+    biodata_filepath=BIODATA_FILE, 
+    biodata_sheet_map=BIODATA_SHEETS_MAP, 
+    column_name_map=FEAT_TO_ECHOPOP_BIODATA_COLUMNS, 
+    subset_dict=BIODATA_MAPPING, 
+    biodata_label_map=BIODATA_LABEL_MAP
+)
+# ---- Remove specimen hauls
+biology.remove_specimen_hauls(dict_df_bio)
+logging.info(
+    "Biodata ingestion complete\n"
+    "'dict_df_bio' created."
+)
+# ==================================================================================================
+# INGEST STRATIFICATION DATA
+logging.info(
+    "Loading stratification files..."
+)
+
+# HAUL-BASED STRATIFICATION DATAFRAME COLUMN NAME MAPPING
+FEAT_TO_ECHOPOP_STRATA_COLUMNS = {
+    "fraction_hake": "nasc_proportion",
+    "haul": "haul_num",
+    "stratum": "stratum_num",
+}
+
+# READ IN STRATA FILE 
+logging.info(
+    f"Load in haul-based stratification: '{HAUL_STRATA_FILE.as_posix()}'."
+)
+df_dict_strata = load_data.load_strata(
+    strata_filepath=HAUL_STRATA_FILE, 
+    strata_sheet_map=HAUL_STRATA_SHEETS_MAP, 
+    column_name_map=FEAT_TO_ECHOPOP_STRATA_COLUMNS
+)
+logging.info(
+    "Haul-based stratification loading complete\n"
+    "'df_dict_strata' created."
+)
+
+# GEOGRAPHIC-BASED STRATIFICATION DATAFRAME COLUMN NAME MAPPING
+FEAT_TO_ECHOPOP_GEOSTRATA_COLUMNS = {
+    "latitude (upper limit)": "northlimit_latitude",
+    "stratum": "stratum_num",
+}
+
+# READ IN GEOSTRATA FILE
+logging.info(
+    f"Load in geographic-based stratification: '{GEOSTRATA_FILE.as_posix()}'."
+)
+df_dict_geostrata = load_data.load_geostrata(
+    geostrata_filepath=GEOSTRATA_FILE, 
+    geostrata_sheet_map=GEOSTRATA_SHEETS_MAP, 
+    column_name_map=FEAT_TO_ECHOPOP_GEOSTRATA_COLUMNS
+)
+logging.info(
+    "Geographic-based stratification loading complete\n"
+    "'df_dict_geostrata' created."
+)
+# ==================================================================================================
+# LOAD KRIGING MESH FILE
+logging.info(
+    f"Loading kriging mesh file: '{KRIGING_MESH_FILE.as_posix()}'."
+)
+
+# KRIGING MESH DATAFRAME COLUMN NAME MAPPING
+FEAT_TO_ECHOPOP_MESH_COLUMNS = {
+    "centroid_latitude": "latitude",
+    "centroid_longitude": "longitude",
+    "fraction_cell_in_polygon": "fraction",
+}
+
+# LOAD MESH
+df_mesh = load_data.load_mesh_data(
+    mesh_filepath=KRIGING_MESH_FILE, 
+    sheet_name=KRIGING_MESH_SHEET, 
+    column_name_map=FEAT_TO_ECHOPOP_MESH_COLUMNS
+)
+logging.info(
+    "Kriging mesh loading complete\n"
+    "'df_mesh' created."
+)
+# ==================================================================================================
+# LOAD ISOBATH FILE
+logging.info(
+    f"Loading isobath file: '{ISOBATH_FILE}'."
+)
+df_isobath = load_data.load_isobath_data(
+    isobath_filepath=ISOBATH_FILE,
+    sheet_name=ISOBATH_SHEET
+)
+logging.info(
+    f"Iosbath loading complete\n"
+    "'df_isobath' created."
+)
+# ==================================================================================================
+# LOAD KRIGING AND VARIOGRAM PARAMETERS
+logging.info(
+    f"Loading variogram and kriging parameters: '{KRIGING_VARIOGRAM_PARAMETERS_FILE.as_posix()}'."
+)
+
+# PARAMETERS DATAFRAME COLUMN NAME MAPPING
+FEAT_TO_ECHOPOP_GEOSTATS_PARAMS_COLUMNS = {
+    "hole": "hole_effect_range",
+    "lscl": "correlation_range",
+    "nugt": "nugget",
+    "powr": "decay_power",
+    "ratio": "aspect_ratio",
+    "res": "lag_resolution",
+    "srad": "search_radius",
+}
+
+# LOAD IN PARAMETERS
+dict_kriging_params, dict_variogram_params = load_data.load_kriging_variogram_params(
+    geostatistic_params_filepath=KRIGING_VARIOGRAM_PARAMETERS_FILE,
+    sheet_name=KRIGING_VARIGORAM_PARAMETERS_SHEET,
+    column_name_map=FEAT_TO_ECHOPOP_GEOSTATS_PARAMS_COLUMNS
+)
+logging.info(
+    "Variogram and kriging parameter loading complete\n"
+    "---- 'dict_variogram_params' created [variogram]\n"
+    "---- 'dict_kriging_params' created [kriging]"
+)
+# ==================================================================================================
+# INITIAL DATA PROCESSING
+# ==================================================================================================
+# APPLY STRATIFICATION DEFINITIONS TO BIODATA AND NASC
+logging.info("Applying strata to datasets...")
+
+# HAUL-BASED STRATA
+logging.info(
+    "Applying haul-based strata to 'dict_df_bio' and 'df_nasc'.\n"
+    "     Default stratum: 0\n"
+    "     New columns:\n"
+    "         INPFC: 'stratum_inpfc'\n"
+    "         KS: 'stratum_ks'"
+)
+# ---- BIODATA [INPFC]
+dict_df_bio = load_data.join_strata_by_haul(data=dict_df_bio,
+                                            strata_df=df_dict_strata["inpfc"],
+                                            default_stratum=0,
+                                            stratum_name="stratum_inpfc")
+# ---- BIODATA [KS]
+dict_df_bio = load_data.join_strata_by_haul(data=dict_df_bio,
+                                            strata_df=df_dict_strata["ks"],
+                                            default_stratum=0,
+                                            stratum_name="stratum_ks")
+# ---- NASC [INPFC]
+df_nasc = load_data.join_strata_by_haul(data=df_nasc,
+                                        strata_df=df_dict_strata["inpfc"],
+                                        default_stratum=0,
+                                        stratum_name="stratum_inpfc")
+# ---- NASC [KS]
+df_nasc = load_data.join_strata_by_haul(data=df_nasc,
+                                        strata_df=df_dict_strata["ks"],
+                                        default_stratum=0,
+                                        stratum_name="stratum_ks")
+
+# GEOGRAPHIC-BASED STRATA
+logging.info(
+    "Applying geographic-based strata to 'df_nasc' and 'df_mesh.\n"
+    "     New columns:\n"
+    "         INPFC: 'geostratum_inpfc'\n"
+    "         KS: 'geostratum_ks'"
+)
+# ---- NASC [INPFC]
+df_nasc = load_data.join_geostrata_by_latitude(data=df_nasc,
+                                               geostrata_df=df_dict_geostrata["inpfc"],
+                                               stratum_name="geostratum_inpfc")
+# ---- NASC [KS]
+df_nasc = load_data.join_geostrata_by_latitude(data=df_nasc,
+                                               geostrata_df=df_dict_geostrata["ks"],
+                                               stratum_name="geostratum_ks")
+# ---- MESH [INPFC]
+df_mesh = load_data.join_geostrata_by_latitude(data=df_mesh, 
+                                               geostrata_df=df_dict_geostrata["inpfc"], 
+                                               stratum_name="geostratum_inpfc")
+# ---- MESH [KS]
+df_mesh = load_data.join_geostrata_by_latitude(data=df_mesh, 
+                                               geostrata_df=df_dict_geostrata["ks"], 
+                                               stratum_name="geostratum_ks")
+logging.info("Strata application complete!")
+# ==================================================================================================
+# BINIFY DATA 
+logging.info(
+    "Binning biodata ['dict_df_bio'] into discrete age and length bins\n"
+    "     Age bins: [1, 2, 3, ..., 20, 21, 22]\n"
+    "     Length bins: [2.0, 4.0, 6.0, ... 76.0, 78.0, 80.0]\n"
+    "     New columns:\n"
+    "         Age: 'age_bin'\n"
+    "         Length: 'length_bin'"
+)
+
+# AGE-BINS
+AGE_BINS = np.linspace(start=1., stop=22, num=22)
+utils.binify(
+    data=dict_df_bio, bins=AGE_BINS, bin_column="age",
+)
+
+# LENGTH-BINS
+LENGTH_BINS = np.linspace(start=2., stop=80., num=40)
+utils.binify(
+    data=dict_df_bio, bins=LENGTH_BINS, bin_column="length", 
+)
+logging.info("Age and length binning complete!")
+# ==================================================================================================
+# FIT LENGTH-WEIGHT REGRESSION
+logging.info("Fitting length-weight regression for each sex and for all fish.")
+
+# CREATE DICTIONARY CONTAINER
+dict_length_weight_coefs = {}
+
+# ALL FISH
+dict_length_weight_coefs["all"] = dict_df_bio["specimen"].assign(sex="all").groupby(["sex"]).apply(
+    biology.fit_length_weight_regression,
+    include_groups=False
+)
+
+# SEX-SPECIFIC
+dict_length_weight_coefs["sex"] = dict_df_bio["specimen"].groupby(["sex"]).apply(
+    biology.fit_length_weight_regression,
+    include_groups=False
+)
+logging.info("Fitting length-weight regression for each sex and for all fish complete!")
+# ==================================================================================================
+# COMPUTE MEAN WEIGHTS PER LENGTH BIN
+logging.info(
+    "Computing the mean weight per length bin for each sex and for all fish.\n"
+    "     Impute missing length bins using modeled weights: True"
+    "     Minimum specimen count per bin: 5"
+    )
+
+# SEX-SPECIFIC
+df_binned_weights_sex = biology.length_binned_weights(
+    data=dict_df_bio["specimen"],
+    length_bins=LENGTH_BINS,
+    regression_coefficients=dict_length_weight_coefs["sex"],
+    impute_bins=True,
+    minimum_count_threshold=5
+)
+
+# ALL FISH
+df_binned_weights_all = biology.length_binned_weights(
+    data=dict_df_bio["specimen"].assign(sex="all"),
+    length_bins=LENGTH_BINS,
+    regression_coefficients=dict_length_weight_coefs["all"],
+    impute_bins=True,
+    minimum_count_threshold=5,
+)
+
+# COMBINE
+binned_weight_table = pd.concat([df_binned_weights_sex, df_binned_weights_all], axis=1)
+logging.info(
+    "Length-binned mean weight calculations complete\n"
+    "'binned_weight_table' created."
+    )
+# ==================================================================================================
+# COMPUTE COUNT DISTRIBUTIONS PER AGE- AND LENGTH-BINS
+logging.info(
+    "Computing the counts per age- and length-bins across sex.\n"
+    "     Stratifying by: 'stratum_ks'"
+    "     Grouping by: 'sex'"
+    )
+
+# DICTIONARY CONTAINER
+dict_df_counts = {}
+
+# AGED
+dict_df_counts["aged"] = get_proportions.compute_binned_counts(
+    data=dict_df_bio["specimen"].dropna(subset=["age", "length", "weight"]), 
+    groupby_cols=["stratum_ks", "length_bin", "age_bin", "sex"], 
+    count_col="length",
+    agg_func="size"
+)
+
+# UNAGED
+dict_df_counts["unaged"] = get_proportions.compute_binned_counts(
+    data=dict_df_bio["length"].copy().dropna(subset=["length"]), 
+    groupby_cols=["stratum_ks", "length_bin", "sex"], 
+    count_col="length_count",
+    agg_func="sum"
+)
+logging.info(
+    "Count distributions across age, length, and sex complete\n"
+    "'dict_df_counts' created."
+    )
+# ==================================================================================================
+# COMPUTE NUMBER PROPORTIONS
+logging.info(
+    "Computing number proportions across age and length bins\n"
+    "     Stratifying by: 'stratum_ks'\n"
+    "     Excluding: 'sex'='unsexed' from 'dict_df_counts['aged']'"
+    )
+dict_df_number_proportions = get_proportions.number_proportions(
+    data=dict_df_counts, 
+    group_columns=["stratum_ks"],
+    exclude_filters={"aged": {"sex": "unsexed"}},
+)
+logging.info(
+    "Number proportions calculation complete\n"
+    "'dict_df_number_proportions' created\n"
+    )
+# ==================================================================================================
+# COMPUTE BINNED WEIGHTS
+logging.info(
+    "Computing the summed weights per age- and length-bins across sex.\n"
+    "     Stratifying by: 'stratum_ks'"
+    "     Grouping by: 'sex'"
+    "     Excluding: 'sex'='unsexed'"
+    )
+
+# DICTIONARY CONTAINER
+dict_df_weight_distr = {}
+
+# AGED
+dict_df_weight_distr["aged"] = get_proportions.binned_weights(
+    length_dataset=dict_df_bio["specimen"],
+    include_filter = {"sex": ["female", "male"]},
+    interpolate_regression=False,
+    contrast_vars="sex",
+    table_cols=["stratum_ks", "sex", "age_bin"]
+)
+
+# UNAGED
+logging.info(
+    "Unaged binned weights require additional processing steps.\n"
+    "     Interpolating binned length-weight regression estimates: True"
+    )
+dict_df_weight_distr["unaged"] = get_proportions.binned_weights(
+    length_dataset=dict_df_bio["length"],
+    length_weight_dataset=binned_weight_table,
+    include_filter = {"sex": ["female", "male"]},
+    interpolate_regression=True,
+    contrast_vars="sex",
+    table_cols=["stratum_ks", "sex"]
+)
+logging.info(
+    "Summed weights per age- and length-bins across sex computation complete\n"
+    "'dict_df_weight_distr' created."
+    )
+# ==================================================================================================
+# COMPUTE WEIGHT PROPORTIONS
+logging.info(
+    "Computing weight proportions across age and length bins\n"
+    "     Stratifying by: 'stratum_ks'"
+    "     Grouping by: 'sex'"
+    )
+
+# DICTIONARY CONTAINER
+dict_df_weight_proportions = {}
+
+# AGED WEIGHT PROPORTIONS
+logging.info("Computing aged weight proportions...")
+dict_df_weight_proportions["aged"] = get_proportions.weight_proportions(
+    weight_data=dict_df_weight_distr, 
+    catch_data=dict_df_bio["catch"], 
+    group="aged",
+    stratum_col="stratum_ks"
+)
+
+# UNAGED SCALING
+logging.info("Scaling unaged binned weights...")
+standardized_sexed_unaged_weights_df = get_proportions.scale_weights_by_stratum(
+    weights_df=dict_df_weight_distr["unaged"], 
+    reference_weights_df=dict_df_bio["catch"].groupby(["stratum_ks"])["weight"].sum(),
+    stratum_col="stratum_ks",
+)
+
+# UNAGED WEIGHT PROPORTIONS
+logging.info(
+    "Computing unaged weight proportions\n"
+    "     Scaling weight proportions in reference to the aged estimates"
+    )
+dict_df_weight_proportions["unaged"] = get_proportions.scale_weight_proportions(
+    weight_data=standardized_sexed_unaged_weights_df, 
+    reference_weight_proportions=dict_df_weight_proportions["aged"], 
+    catch_data=dict_df_bio["catch"], 
+    number_proportions=dict_df_number_proportions,
+    binned_weights=binned_weight_table["all"],
+    group="unaged",
+    group_columns = ["sex"],
+    stratum_col = "stratum_ks"
+)
+logging.info(
+    "Weight proportions calculation complete\n"
+    "'dict_df_weight_proportions' created."
+    )
+# ==================================================================================================
+# NASC TO BIOMASS CONVERSION
+# ==================================================================================================
+# INVERSION
+logging.info(
+    "Beginning inversion based on hake-specific TS-length regression coefficients\n"
+    "     Model: 20.0 x log[10](L) + -68.0\n"
+    "     Stratifying by: 'stratum_ks'\n"
+    "     Imputing missing strata: True\n"
+    "     Treating hauls as replicates: True"
+    )
+
+# DEFINE INVERSION MODEL PARAMETERS
+MODEL_PARAMETERS = {
+    "ts_length_regression": {
+        "slope": 20.,
+        "intercept": -68.
+    },
+    "stratify_by": ["stratum_ks"],
+    "expected_strata": df_dict_strata["ks"].stratum_num.unique(),
+    "impute_missing_strata": True,
+    "haul_replicates": True,
+}
+
+# INITIALIZE INVERSION OBJECT
+invert_hake = inversion.InversionLengthTS(MODEL_PARAMETERS)
+logging.info("Inversion-class object 'invert_hake' created...")
+
+# INVERT NUMBER DENSITY
+df_nasc = invert_hake.invert(
+    df_nasc=df_nasc, df_length=[dict_df_bio["length"], dict_df_bio["specimen"]]
+)
+logging.info(
+    "Number density inversion complete\n"
+    "     New column in 'df_nasc':\n"
+    "         Number density (animals nm^-2): 'number_density'"
+    )
+# ==================================================================================================
+# CONVERT TO BIOMASS
+logging.info("Converting number density estimates into biomass estimates")
+
+# SET TRANSECT INTERVAL DISTANCES
+logging.info(
+    "Defining transect interval distances...\n"
+    "     Along-transect interval distance (nmi) threshold: 0.5 nmi"
+)
+transect.compute_interval_distance(df_nasc=df_nasc, interval_threshold=0.05)
+
+# SET TRANSECT INTERVAL AREAS
+logging.info("Defining transect interval areas...")
+df_nasc["area_interval"] = (
+    df_nasc["transect_spacing"] * df_nasc["distance_interval"]
+)
+
+# COMPUTE ABUNDANCE
+logging.info(
+    "Compute interval abundances...\n"
+    "     Stratifying by: 'stratum_ks'\n"
+    "     Grouping by: 'sex'\n"
+    "     Excluding: 'sex'='unsexed' from 'dict_df_number_proportions'"    
+)
+biology.compute_abundance(
+    dataset=df_nasc,
+    stratify_by=["stratum_ks"],
+    group_by=["sex"],
+    exclude_filter={"sex": "unsexed"},
+    number_proportions=dict_df_number_proportions
+)
+
+# COMPUTE STRATUM-AVERAGED WEIGHTS
+df_averaged_weight = get_proportions.stratum_averaged_weight(
+    proportions_dict=dict_df_number_proportions, 
+    binned_weight_table=binned_weight_table,
+    stratify_by=["stratum_ks"],
+    group_by=["sex"],
+)
+
+# COMPUTE BIOMASS
+logging.info(
+    "Compute interval biomass...\n"
+    "     Stratifying by: 'stratum_ks'\n"
+    "     Grouping by: 'sex'\n"  
+)
+biology.compute_biomass(
+    dataset=df_nasc,
+    stratify_by=["stratum_ks"],
+    group_by=["sex"],
+    df_average_weight=df_averaged_weight,
+)
+logging.info(
+    "NASC to biomass conversion complete\n"
+    "     New columns in 'df_nasc':\n"
+    "         Sex-specific number densities (animals nmi^-2): "
+    "'number_density_female'/'number_density_male'\n"
+    "         Abundance (animals): 'abundance'/'abundance_female'/'abundance_male'\n"
+    "         Biomass density (kg nmi^-2): 'biomass_density'/'biomass_density_female'/"
+    "'biomass_density_male'\n"
+    "         Biomass (kg): 'biomass'/'biomass_female'/'biomass_male'"
+    )
+# ==================================================================================================
+# DISTRIBUTE POPULATION ESTIMATES ACROSS AGE AND LENGTH BINS
+logging.info(
+    "Distribute population estimates across age- and length-bins\n"
+    "     Stratifying by: 'stratum_ks'\n"
+    "     Grouping by: 'sex'"
+)
+
+# ABUNDANCE
+logging.info("Distributing abundances...")
+dict_transect_abundance_table = apportion.distribute_population_estimates(
+    data=df_nasc,
+    proportions=dict_df_number_proportions,
+    variable="abundance",
+    group_by=["sex", "age_bin", "length_bin"],
+    stratify_by=["stratum_ks"],
+)
+logging.info("Abundance distributions complete\n'dict_transect_abundance_table' created.")
+# BIOMASS [ALL]
+logging.info("Distributing biomass...")
+dict_transect_biomass_table = apportion.distribute_population_estimates(
+    data=df_nasc,
+    proportions=dict_df_weight_proportions,
+    variable="biomass",
+    group_by=["sex", "age_bin", "length_bin"],
+    stratify_by=["stratum_ks"],
+)
+logging.info("Biomass distribution complete\n'dict_transect_biomass_table' created.")
+# BIOMASS [AGED-ONLY]
+logging.info("Distributing biomass...\n     Aged-only weight proportions: True")
+df_transect_aged_biomass_table = apportion.distribute_population_estimates(
+    data=df_nasc,
+    proportions=dict_df_weight_proportions["aged"],
+    variable="biomass",
+    group_by=["sex", "age_bin", "length_bin"],
+    stratify_by=["stratum_ks"],
+)
+logging.info("Aged-biomass distribution complete\n'df_transect_aged_biomass_table' created.")
+# ==================================================================================================
+# GEOSTATISTICS
+# ==================================================================================================
+# INITIAL
+logging.info("Beginning geostatistical analysis...")
+# ==================================================================================================
+# COORDINATE TRANSFORMATION
+logging.info(
+    "Transform spatial coordinates for 'df_nasc' and 'df_mesh'\n"
+    "     Reference coordinates: 'df_isobath'\n"
+    "     Longitudinal offset: -124.78338 deg.E\n"
+    "     Latitudinal offset: 45.0 deg.N"
+)
+
+# NASC
+df_nasc, delta_longitude, delta_latitude = spatial.transform_coordinates(
+    data = df_nasc,
+    reference = df_isobath,
+    x_offset = -124.78338,
+    y_offset = 45.,   
+)
+
+# MESH
+df_mesh, _, _ = spatial.transform_coordinates(
+    data = df_mesh,
+    reference = df_isobath,
+    x_offset = -124.78338,
+    y_offset = 45.,   
+    delta_x=delta_longitude,
+    delta_y=delta_latitude
+)
+logging.info(
+    "Coordinate transformation complete\n"
+    "     New columns:\n"
+    "          Transformed longitude: 'x'\n"
+    "          Transformed latitude: 'y'\n"
+)
+# ==================================================================================================
+# VARIOGRAM ANALYSIS
+logging.info(
+    "Beginning variogram analysis\n"
+    "     Normalized lag resolution: 0.002\n"
+    "     Number of lags: 30\n"
+)
+
+# INITIALIZE VARIOGRAM-CLASS OBJECT
+vgm = variogram.Variogram(
+    lag_resolution=0.002,
+    n_lags=30,
+    coordinate_names=("x", "y"),
+)
+logging.info("Variogram-class object 'vgm' created...")
+
+# EMPIRICAL VARIOGRAM
+logging.info(
+    "Computing the empirical variogram\n"
+    "     Variable: 'biomass_density'\n"
+    "     Applying azimuth angle filter: True\n"
+    "     Azimuth angle filter: 180.0 deg.\n"
+)
+vgm.calculate_empirical_variogram(
+    data=df_nasc,
+    variable="biomass_density",
+    azimuth_filter=True,
+    azimuth_angle_threshold=180.,
+)
+
+# SET UP FITTING PARAMETERS
+# ----- lmfit.Parameters tuples: (NAME VALUE VARY MIN  MAX  EXPR  BRUTE_STEP)
+logging.info(
+    f"Optimizing variogram parameters using non-linear least-squares\n"
+    f"     Model: Exponential-Bessel (['exponential', 'bessel'])\n"
+    f"     Initial values:\n"
+    f"          Nugget: {dict_variogram_params["nugget"]}\n"
+    f"          Sill: {dict_variogram_params["sill"]}\n"
+    f"          Correlation range: {dict_variogram_params["correlation_range"]}\n"
+    f"          Hole effect range: {dict_variogram_params["hole_effect_range"]}\n"
+    f"          Decay power exponent: {dict_variogram_params["decay_power"]}"
+)
+variogram_parameters_lmfit = Parameters()
+variogram_parameters_lmfit.add_many(
+    ("nugget", dict_variogram_params["nugget"], True, 0.),
+    ("sill", dict_variogram_params["sill"], True, 0.),
+    ("correlation_range", dict_variogram_params["correlation_range"], True, 0.),
+    ("hole_effect_range", dict_variogram_params["hole_effect_range"], True, 0.),
+    ("decay_power", dict_variogram_params["decay_power"], True, 1.25, 1.75),
+)
+
+# OPTIMIZATION PARAMETERS
+OPTIM_ARGS = {
+    "max_nfev": None, "ftol": 1e-08, "gtol": 1e-8, "xtol": 1e-8, "diff_step": None, 
+    "tr_solver": "exact", "x_scale": 1., "jac": "2-point"
+}
+logging.info(
+    f"Optimization arguments:\n"
+    f"{OPTIM_ARGS}"
+)
+
+# RUN MINIMIZER
+best_fit_parameters = vgm.fit_variogram_model(
+    model=["exponential", "bessel"],
+    model_parameters=variogram_parameters_lmfit,
+    optimizer_kwargs=OPTIM_ARGS,
+)
+logging.info(
+    f"Variogram parameter fitting complete\n"
+    f"     Best-fit parameters:\n"
+    f"     {best_fit_parameters}"
+)
+# ==================================================================================================
+# KRIGING ANALYSIS
+logging.info(
+    f"Beginning kriging analysis\n"
+    f"     Using best-fit variogram model and parameters: True\n"
+    f"     Kriging parameters:\n"
+    f"          Normalized search radius: {best_fit_parameters["correlation_range"] * 3}\n"
+    f"          Minimum nearest-neighbor count: 3\n"
+    f"          Maximum nearest-neighbor count: 10\n"
+    f"          Anisotropic aspect ratio: 0.001"
+)
+
+# KRIGING PARAMETERS CONTAINER
+KRIGING_PARAMETERS = {
+    "search_radius": best_fit_parameters["correlation_range"] * 3,
+    "aspect_ratio": 0.001,
+    "k_min": 3,
+    "k_max": 10,
+}  
+
+# VARIOGRAM PARAMETERS CONTAINER
+VARIOGRAM_PARAMETERS = {
+    "model": ["exponential", "bessel"],
+    **best_fit_parameters
+}
+
+# INITIALIZE CLASS OBJECT
+krg = kriging.Kriging(
+    mesh=df_mesh,
+    kriging_params=KRIGING_PARAMETERS,
+    variogram_params=VARIOGRAM_PARAMETERS,
+    coordinate_names=("x", "y"),
+)
+logging.info("Kriging-class object 'krg' created...")
+
+# RUN KRIGING
+logging.info(
+    "Interpolating population estimates using ordinary kriging\n"
+    "     Variable: 'biomass_density'\n"
+    "     Extrapolation (full mesh): False\n"
+    "          Cropping method: `FEAT.fun.transect_ends_crop`\n"
+    "          Latitude resolution: 1.25 nmi\n"
+    "          Transect-mesh region mapping: `FEAT.parameters.transect_mesh_region_2019`\n"
+    "     Custom nearest neighbor search strategy: `FEAT.fun.western_boundary_search_strategy\n"
+    "          Maximum latitude: 51.0 deg.N\n"
+    "     Default mesh cell area: 6.25 nmi^2\n"
+)
+# ---- Crop mesh
+krg.crop_mesh(
+    crop_function=CROP_METHOD,
+    transects=df_nasc,
+    latitude_resolution=1.25/60.,
+    transect_mesh_region_function=TRANSECT_MESH_REGION_MAP,
+)
+# ---- Get western extents of transect boundaries
+transect_western_extents = FEAT.get_survey_western_extents(
+    transects=df_nasc,
+    coordinate_names=("x", "y"),
+    latitude_threshold=51.
+)
+# ---- Register the custom search strategy
+krg.register_search_strategy("FEAT_strategy", FEAT.western_boundary_search_strategy)
+logging.info(
+    "Custom nearest neighbor search strategy registered by 'krg' as 'FEAT_strategy'."
+)
+# ---- Define keyword arguments
+FEAT_STRATEGY_KWARGS = {
+    "western_extent": transect_western_extents,
+}
+# ---- Perform ordinary kriging
+df_kriged_results = krg.krige(
+    transects=df_nasc,
+    variable="biomass_density",
+    extrapolate=False,
+    default_mesh_cell_area=6.25,
+    adaptive_search_strategy="FEAT_strategy",
+    custom_search_kwargs=FEAT_STRATEGY_KWARGS,
+)
+logging.info(
+    f"Kriging complete\n"
+    f"'df_kriged_results' created."
+)
+# ==================================================================================================
+# CONVERT BIOMASS DENSITY TO NASC
+logging.info(
+    "Converting biomass density estimates into NASC\n"
+    "     Stratifying by: 'geostratum_ks'/'stratum_ks'\n"
+    "     Grouping by: 'sex'\n"
+    "     Using stratum weights for all fish: True"
+)
+
+# CONVERT TO BIOMASS
+df_kriged_results["biomass"] = df_kriged_results["biomass_density"] * df_kriged_results["area"]
+logging.info("New column in 'df_kriged_results': 'biomass'")
+
+# BIOMASS TO NASC
+apportion.mesh_biomass_to_nasc(
+    mesh_data_df=df_kriged_results,
+    biodata=dict_df_weight_proportions,
+    group_by=["sex"],
+    mesh_biodata_link={"geostratum_ks": "stratum_ks"},
+    stratum_weights_df=df_averaged_weight["all"],
+    stratum_sigma_bs_df=invert_hake.sigma_bs_strata,    
+)
+logging.info(
+    "Biomass density to NASC conversion complete\n"
+    "    New columns in `df_kriged_results`\n"
+    "        Biomass (kg): 'biomass'/'biomass_female'/'biomass_male'\n"
+    "        Abundance (animals): 'abundance'/'abundance_female'/'abundance_male'\n"
+    "        NASC (m^2 nmi^-2): 'nasc'"
+)


### PR DESCRIPTION
This PR includes two new workflows:
- `feat_hake_age1_excluded.py`: Running the complete workflow when age-1 fish are excluded, with additional options for removing age-1 dominated hauls for specific survey years.
- `feat_hake_kriging_without_extrapolation.py`: Running the hake survey workflow through the geostatistics where the kriged estimates are not extrapolated over the entire ingested mesh.

Additions:
- Transect-mesh-region definition generating functions have been created for every year, which were all adapted directly from the associated `EchoPro` `*.m` files in `EchoPro_matlab/input_files/Region_def_files/*`. At least in the version I have, these were only generated for survey years between 1995 and 2019. 

Bug-fixes:
- For cases where age-1 dominated hauls are removed, there were resulting `NaN` values that contaminated pre-kriged (i.e. transect) population estimates. This is due to cases where the removal of particular hauls can encompass one or more strata in their entirety, so the merging/reindexing operations are unable to resolve an appropriate value. This has been rectified. 

