### PR TITLE
Fix `_version.py` in .gitignore to prevent tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .DS_Store
-_echopop_version.py
+*_version.py
 .vscode
 
 # ignore output reports, if they were produced

--- a/echopop/__init__.py
+++ b/echopop/__init__.py
@@ -1,1 +1,1 @@
-from _echopop_version import version as __version__  # noqa
+from ._version import version as __version__  # noqa

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ include = ["echopop*"]
 version_scheme = "post-release"
 local_scheme = "no-local-version"
 fallback_version = "0.0.0"
-write_to = "_echopop_version.py"
+write_to = "echopop/_version.py"
 write_to_template = 'version = "{version}"  # noqa'
 
 [tool.black]


### PR DESCRIPTION
Currently the file written out by setuptools_scm is not ignored by git correctly due to location mismatches.

This PR changes the location to `_echopop_version.py` from `echopop/_version.py` for it to be properly ignored by git (that part has already been set up before). 

This PR also removes `echopop/_version.py`.