### PR TITLE
Add "strata" and "geostrata" to prominent places in docs

### DIFF
--- a/docs/example_notebooks/stratify_data.ipynb
+++ b/docs/example_notebooks/stratify_data.ipynb
@@ -31,7 +31,11 @@
    "source": [
     "## Import necessary modules\n",
     "\n",
-    "There are two types of stratification files that Echopop can expect to read in: 1) haul-based and 2) latitude-based. Functions from the `ingest` sub-package can be used to read in and preprocess these files. Similar to the other data ingestion steps, some column renaming may be required for compatibility with Echopop. "
+    "There are two types of stratification files that Echopop can expect to read in:\n",
+    "1) haul-based -- the `\"strata\"`; and\n",
+    "2) latitude-based -- the `\"geostrata\"`.\n",
+    "\n",
+    "Functions from the `ingest` sub-package can be used to read in and preprocess these files. Similar to the other data ingestion steps, some column renaming may be required to be compatible with Echopop. "
    ]
   },
   {
@@ -39,7 +43,7 @@
    "id": "94d73e8a",
    "metadata": {},
    "source": [
-    "## Haul-based stratification\n",
+    "## Haul-based stratification (`\"strata\"`)\n",
     "\n",
     "The haul-based stratification files can include any number of different stratification definitions so long as they are assigned different names. For instance, if a spreadsheet has two sheets labeled \"INPFC\" and \"KS\", then those can be mapped using:"
    ]
@@ -103,7 +107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "4b69d273",
    "metadata": {
     "tags": [
@@ -132,8 +136,7 @@
     "# Add INPFC to biodata\n",
     "dict_df_bio = join_strata_by_haul(dict_df_bio,\n",
     "                                  df_dict_strata[\"inpfc\"],\n",
-    "                                  stratum_name=\"stratum_inpfc\")\n",
-    "\n"
+    "                                  stratum_name=\"stratum_inpfc\")\n"
    ]
   },
   {
@@ -141,7 +144,7 @@
    "id": "2eefe971",
    "metadata": {},
    "source": [
-    "## Latitude-based stratification\n",
+    "## Latitude-based stratification (`\"geostrata\"`)\n",
     "\n",
     "Alternatively, any georeferenced data with the correctly projected/referenced column `\"latitude\"` can be stratified based on their latitudinal position instead of haul number. In this instance, only the NASC data has the column `latitude`; however, this information could be supplied to the biological data for similar functionality. This first requires reading in the latitude-based stratification file, which is referred to as the \"geostratification\" to differentiate it from the haul-based mapping. This can be loaded in via the `load_geostrata` function."
    ]


### PR DESCRIPTION
This PR make minor additions to add the naming `"strata"` and `"geostrata"` to prominent places in the doc page "Stratify acoustic and biological data."

This addresses #439.