### PR TITLE
Resolve specimen-catch weight overlap

### DIFF
--- a/echopop/workflows/nwfsc_feat/biology.py
+++ b/echopop/workflows/nwfsc_feat/biology.py
@@ -470,11 +470,7 @@ def remove_specimen_hauls(
     haul_numbers = biodata_dict["length"]["haul_num"].unique()
 
     # Find incompatible hauls and create copy
-    catch = (
-        biodata_dict["catch"]
-        .loc[biodata_dict["catch"]["haul_num"].isin(haul_numbers)]
-        .copy()
-    )
+    catch = biodata_dict["catch"].loc[biodata_dict["catch"]["haul_num"].isin(haul_numbers)].copy()
 
     # Sum up the specimen haul weights
     specimen_haul_weights = biodata_dict["specimen"].groupby(["haul_num"])["weight"].sum()

--- a/echopop/workflows/nwfsc_feat/tests/processing/test_biology.py
+++ b/echopop/workflows/nwfsc_feat/tests/processing/test_biology.py
@@ -320,9 +320,10 @@ def test_remove_speciman_hauls(biological_data):
     """
 
     # Pre-process
-    biodata = {k: v.rename(
-        columns={"haul": "haul_num", "weight_in_haul": "weight"}
-    ) for k, v in biological_data.items()}
+    biodata = {
+        k: v.rename(columns={"haul": "haul_num", "weight_in_haul": "weight"})
+        for k, v in biological_data.items()
+    }
     biodata["specimen"]["weight"] = [1, 2, 3, 4]
 
     # Swap out haul number 4 from length data
@@ -346,7 +347,10 @@ def test_remove_speciman_hauls(biological_data):
     )
     assert all(
         (
-            biodata["specimen"].set_index("haul_num")["weight"] + 
-            biodata["catch"].set_index("haul_num")["weight"]
-        ).dropna().values == biological_data["catch"]["weight_in_haul"][:3]
+            biodata["specimen"].set_index("haul_num")["weight"]
+            + biodata["catch"].set_index("haul_num")["weight"]
+        )
+        .dropna()
+        .values
+        == biological_data["catch"]["weight_in_haul"][:3]
     )


### PR DESCRIPTION
This addressed #438 with respect to the overlap of specimen and catch weights. The `remove_specimen_hauls` function has now been updated to do this removal, which is an already optional in-place function.